### PR TITLE
Add Metadata classes

### DIFF
--- a/Core/automation/lib/python/core/metadata.py
+++ b/Core/automation/lib/python/core/metadata.py
@@ -93,7 +93,7 @@ class metadata_namespace(MutableMapping):
     def __len__(self): return len(self._configuration)
     def __setitem__(self, key, value): return self.set_config_value(key, value)
     def __getitem__(self, key): return self.get_config_value(key)
-    def __delitem__(self, key): self.delete_config_value(key)
+    def __delitem__(self, key): return self.delete_config_value(key)
 
     def load(self):
         '''Loads the namespace from the metadata registry.
@@ -122,12 +122,12 @@ class metadata_namespace(MutableMapping):
         # save to the registry
         MetadataRegistry.add(Metadata(self._keyUID, str(self._value), strConfiguration))
         del strConfiguration
-    
+
     def remove(self):
         '''Deletes this namespace from the registry.
         This instance will be preserved and can be written back to the registry.'''
         MetadataRegistry.remove(self._keyUID)
-    
+
     def set_value(self, value, save=True):
         '''Sets the namespace "value".
         Set "save" flag to False to skip saving to openHAB. You must take care to manually save
@@ -135,9 +135,19 @@ class metadata_namespace(MutableMapping):
         self._value = value
         if save: self.save()
 
+    @value.setter
+    def value(self, value):
+        '''Sets the namespace "value" and saves to the registry.'''
+        return self.set_value(value)
+
     def get_value(self):
         '''Gets the namespace "value".'''
         return self._value
+
+    @property
+    def value(self):
+        '''Returns the namespace "value".'''
+        return self.get_value
 
     def set_config_value(self, key, value, save=True):
         '''Sets the namespace configuration value for the specified key.

--- a/Core/automation/lib/python/core/metadata.py
+++ b/Core/automation/lib/python/core/metadata.py
@@ -3,83 +3,141 @@ Wrapper class for using Item Metadata
 '''
 
 from collections import MutableMapping
+import re
 from org.eclipse.smarthome.core.items import Metadata, MetadataKey
 from core.log import logging, LOG_PREFIX
-log = logging.getLogger(LOG_PREFIX + ".metadata")
+log = logging.getLogger(LOG_PREFIX + ".core.metadata")
 from core import osgi
 MetadataRegistry = osgi.get_service("org.eclipse.smarthome.core.items.MetadataRegistry")
 
 __all__ = [ "namespace_exists", "item_metadata", "metadata_namespace" ]
 
+# valid characters for names
+_valid_chars_re = "^[a-zA-Z][a-zA-Z0-9_]*$"
+
 
 def namespace_exists(item_name, namespace):
-    '''Returns True if metadata namespace exists'''
+    '''
+    Returns True if metadata namespace exists
+    '''
+    if not re.match(_valid_chars_re, namespace):
+        raise ValueError("'{}' is not a valid namespace name".format(namespace))
     return False if MetadataRegistry.get(MetadataKey(namespace, item_name)) is None else True
 
-def _resolveType(value):
-    '''Attempts to resolve the type of the metadata value.
+def _item_exists(item_name):
+    '''
+    Returns True if item exists
+    '''
+    from core.jsr223.scope import itemRegistry
+    from org.eclipse.smarthome.core.items import ItemNotFoundException
+    try:
+        itemRegistry.getItem(item_name)
+        return True
+    except ItemNotFoundException:
+        return False
+
+def _resolve_type(value):
+    '''
+    Attempts to resolve the type of the metadata value.
     It will return the value as the python type if possible,
-    otherwise will return value as string'''
+    otherwise will return value as string
+    '''
     if str(value).lower().strip() == "true":
         return True
     elif str(value).lower().strip() == "false":
         return False
+    elif str(value).lower().strip() == "none":
+        return None
     else:
         # attempt to cast to int
-        try: return int(str(value))
-        except ValueError: pass
+        try:
+            return int(str(value).strip())
+        except ValueError:
+            pass
         # attempt to cast to float
-        try: return float(str(value))
-        except ValueError: pass
+        try:
+            return float(str(value).strip())
+        except ValueError:
+            pass
         # not a number
-        return str(value)
+        return str(value).strip()
 
 class item_metadata(MutableMapping):
     def __init__(self, item_name):
-        '''This is a manager class that can be used to manage multiple
+        '''
+        This is a manager class that can be used to manage multiple
         metadata namespaces for a single item from one place.
         - This class behaves like a dict of "metadata_namespace" objects.
         - Namespaces can be added by name with "add_namespace(name)"
-        (attempting to add a namespace that already exists will raise a KeyError)'''
+        (attempting to add a namespace that already exists will raise a KeyError)
+        '''
+        if not _item_exists(item_name):
+            raise ValueError("Item '{}' does not exist".format(item_name))
         self._item_name = item_name
         self._namespaces = {}
 
-    def __iter__(self): return iter(self._namespaces)
-    def __len__(self): return len(self._namespaces)
-    def __setitem__(self, key, value): raise AttributeError("Direct assignment to keys not possible")
-    def __getitem__(self, key): return self._namespaces[key]
-    def __delitem__(self, key): self.delete_namespace(key)
+    def __iter__(self):
+        return iter(self._namespaces)
+
+    def __len__(self):
+        return len(self._namespaces)
+
+    def __setitem__(self, key, value):
+        raise AttributeError("Direct assignment to keys not possible")
+
+    def __getitem__(self, key):
+        return self._namespaces[key]
+
+    def __delitem__(self, key):
+        self.delete_namespace(key)
 
     def add_namespace(self, name):
-        '''Creates a new namespace instance and loads it from the registry
-        if it exists.'''
-        if name in self._namespaces: raise KeyError
-        else: self._namespaces[name] = metadata_namespace(self._item_name ,name)
+        '''
+        Creates a new namespace instance and loads it from the registry
+        if it exists.
+        '''
+        if name in self._namespaces:
+            raise KeyError
+        else:
+            self._namespaces[name] = metadata_namespace(self._item_name ,name)
 
     def delete_namespace(self, name, remove=False):
-        '''Deletes the specified namespace from this object. It will not
-        remove the namespace from openHAB unless the "remove" flag is set'''
-        if name not in self._namespaces: raise KeyError
+        '''
+        Deletes the specified namespace from this object. It will not
+        remove the namespace from openHAB unless the "remove" flag is set
+        '''
+        if name not in self._namespaces:
+            raise KeyError
         else:
-            if remove: self._namespaces[name].remove
+            if remove:
+                self._namespaces[name].remove
             self._namespaces.pop(name, None)
 
 
 class metadata_namespace(MutableMapping):
     def __init__(self, item_name, name, value=None, configuration={}, load=True, save=False):
-        '''Item metadata namespace
+        '''
+        Item metadata namespace
         If "load" is set the namespace will be loaded from the registry. If it 
         exists "value" and "configuration" will be overwritten if provided. 
         If "save" is set the namespace will be written immediately to the 
         registry. This will overwrite the namespace if it exists already. 
-        If the "load" flag is set the "save" flag will be ignored.'''
+        If the "load" flag is set the "save" flag will be ignored.
+        '''
         log.debug("Metadata: Initializing namespace object for item '{item}' namespace '{namespace}'".format( \
             item=item_name, namespace=name))
+        if not _item_exists(item_name):
+            raise ValueError("Item '{}' does not exist".format(item_name))
         self._item_name = item_name
+
+        if not re.match(_valid_chars_re, name):
+            raise ValueError("'{}' is not a valid namespace name".format(name))
         self._name = name
-        self._keyUID = MetadataKey(self._name, self._item_name)
+
+        self._key_uid = MetadataKey(self._name, self._item_name)
         self._value = value
         self._configuration = configuration
+
         if load: 
             log.debug("Metadata: Load on initialize for item '{item}' namespace '{namespace}'".format( \
                 item=item_name, namespace=name))
@@ -89,105 +147,151 @@ class metadata_namespace(MutableMapping):
                 item=item_name, namespace=name, value=str(value), configuration=str(configuration)))
             self.save()
     
-    def __iter__(self): return iter(self._configuration)
-    def __len__(self): return len(self._configuration)
-    def __setitem__(self, key, value): return self.set_config_value(key, value)
-    def __getitem__(self, key): return self.get_config_value(key)
-    def __delitem__(self, key): return self.delete_config_value(key)
+    def __iter__(self):
+        return iter(self._configuration)
+
+    def __len__(self):
+        return len(self._configuration)
+
+    def __setitem__(self, key, value):
+        return self.set_config_value(key, value)
+
+    def __getitem__(self, key):
+        return self.get_config_value(key)
+
+    def __delitem__(self, key):
+        return self.delete_config_value(key)
 
     def load(self):
-        '''Loads the namespace from the metadata registry.
-        THIS WILL OVERWRITE ANY UNSAVED CHANGES TO THIS INSTANCE!'''
+        '''
+        Loads the namespace from the metadata registry.
+        THIS WILL OVERWRITE ANY UNSAVED CHANGES TO THIS INSTANCE!
+        '''
         log.debug("Metadata: Getting metadata for item '{item}' from namespace '{namespace}'".format( \
             item=self._item_name, namespace=self._name))
         # read from registry
-        metadata = MetadataRegistry.get(self._keyUID)
+        metadata = MetadataRegistry.get(self._key_uid)
         log.debug("Metadata: {metadata}".format( \
             metadata=str(metadata)))
         # parse data
         if metadata is not None: # namespace exists
-            self._value = _resolveType(metadata.value)
+            self._value = _resolve_type(metadata.value)
             # load all configuration items into namespace dict
             self._configuration = {}
             for key, value in metadata.configuration.iteritems():
-                self._configuration[str(key)] = _resolveType(value)
+                self._configuration[str(key)] = _resolve_type(value)
 
     def save(self):
-        '''Saves the namespace to the metadata registry.
+        '''
+        Saves the namespace to the metadata registry.
         (This is done automatically when changes to the value or configuration are made
-        unless the "save" flag was set to false when making those changes)'''
+        unless the "save" flag was set to false when making those changes)
+        '''
         # convert all values to strings
+        if self._value is None:
+            strValue = "None"
+        else:
+            strValue = str(self._value)
         strConfiguration = {}
-        for key, value in self._configuration: strConfiguration[key] = str(value)
+        for key, value in self._configuration:
+            strConfiguration[key] = str(value)
         # save to the registry
-        MetadataRegistry.add(Metadata(self._keyUID, str(self._value), strConfiguration))
+        MetadataRegistry.add(Metadata(self._key_uid, strValue, strConfiguration))
         del strConfiguration
 
     def remove(self):
-        '''Deletes this namespace from the registry.
-        This instance will be preserved and can be written back to the registry.'''
-        MetadataRegistry.remove(self._keyUID)
+        '''
+        Deletes this namespace from the registry.
+        This instance will be preserved and can be written back to the registry.
+        '''
+        MetadataRegistry.remove(self._key_uid)
 
     def set_value(self, value, save=True):
-        '''Sets the namespace "value".
+        '''
+        Sets the namespace "value".
         Set "save" flag to False to skip saving to openHAB. You must take care to manually save
-        using the "save()" method or setting another element with the "save" flag set to True.'''
+        using the "save()" method or setting another element with the "save" flag set to True.
+        '''
         self._value = value
-        if save: self.save()
+        if save:
+            self.save()
 
     @value.setter
     def value(self, value):
-        '''Sets the namespace "value" and saves to the registry.'''
+        '''
+        Sets the namespace "value" and saves to the registry.
+        '''
         return self.set_value(value)
 
     def get_value(self):
-        '''Gets the namespace "value".'''
+        '''
+        Gets the namespace "value".
+        '''
         return self._value
 
     @property
     def value(self):
-        '''Returns the namespace "value".'''
+        '''
+        Returns the namespace "value".
+        '''
         return self.get_value
 
     def set_config_value(self, key, value, save=True):
-        '''Sets the namespace configuration value for the specified key.
+        '''
+        Sets the namespace configuration value for the specified key.
         You can also use the dict method "metadata_namespace[key] = value"
         Set "save" flag to False to skip saving to openHAB. You must take care to manually save
-        using the "save()" method or setting another element with the "save" flag set to True.'''
+        using the "save()" method or setting another element with the "save" flag set to True.
+        '''
         self._configuration[str(key)] = value
-        if save: self.save()
+        if save:
+            self.save()
 
     def get_config_value(self, key):
-        '''Gets the value for the specified configuration key.
-        You can also use the dict method "value = metadata_namespace[key]"'''
+        '''
+        Gets the value for the specified configuration key.
+        You can also use the dict method "value = metadata_namespace[key]"
+        '''
         return self._configuration.get(str(key))
 
     def delete_config_value(self, key, save=True):
-        '''Deletes the specified key from the configuration.
+        '''
+        Deletes the specified key from the configuration.
         You can also use the dict method "del metadata_namespace[key]"
         Set "save" flag to False to skip saving to openHAB. You must take care to manually save
-        using the "save()" method or setting another element with the "save" flag set to True.'''
+        using the "save()" method or setting another element with the "save" flag set to True.
+        '''
         self._configuration.pop(str(key), None)
-        if save: self.save()
+        if save:
+            self.save()
 
     def set_configuration(self, configuration, save=True):
-        '''Allows setting the entire configuration dict.
+        '''
+        Allows setting the entire configuration dict.
         THIS WILL OVERWRITE THE EXISTING CONFIGURATION DICT!
         Set "save" flag to False to skip saving to openHAB. You must take care to manually save
-        using the "save()" method or setting another element with the "save" flag set to True.'''
-        if not isinstance(configuration, dict): raise TypeError
+        using the "save()" method or setting another element with the "save" flag set to True.
+        '''
+        if not isinstance(configuration, dict):
+            raise TypeError("Must supply a dictionary")
         self._configuration = configuration
 
     def add_configuration(self, configuration, save=True):
-        '''Allows adding an iterable list or dict of new key-value pairs to the configuration.
+        '''
+        Allows adding an iterable list or dict of new key-value pairs to the configuration.
         Set "save" flag to False to skip saving to openHAB. You must take care to manually save
-        using the "save()" method or setting another element with the "save" flag set to True.'''
+        using the "save()" method or setting another element with the "save" flag set to True.
+        '''
         self._configuration.update(configuration)
-        if save: self.save()
+        if save:
+            self.save()
 
     def clear_configuration(self, save=True):
-        '''Clears all keys and values in the configuration dict.
+        '''
+        Clears all keys and values in the configuration dict.
         Set "save" flag to False to skip saving to openHAB. You must take care to manually save
-        using the "save()" method or setting another element with the "save" flag set to True.'''
+        using the "save()" method or setting another element with the "save" flag set to True.
+        '''
         self._configuration = {}
-        if save: self.save()
+        if save:
+            self.save()

--- a/Core/automation/lib/python/core/metadata.py
+++ b/Core/automation/lib/python/core/metadata.py
@@ -77,6 +77,7 @@ class metadata_namespace(MutableMapping):
             item=item_name, namespace=name))
         self._item_name = item_name
         self._name = name
+        self._keyUID = MetadataKey(self._name, self._item_name)
         self._value = value
         self._configuration = configuration
         if load: 
@@ -100,7 +101,7 @@ class metadata_namespace(MutableMapping):
         log.debug("Metadata: Getting metadata for item '{item}' from namespace '{namespace}'".format( \
             item=self._item_name, namespace=self._name))
         # read from registry
-        metadata = MetadataRegistry.get(MetadataKey(self._name, self._item_name))
+        metadata = MetadataRegistry.get(self._keyUID)
         log.debug("Metadata: {metadata}".format( \
             metadata=str(metadata)))
         # parse data
@@ -119,13 +120,13 @@ class metadata_namespace(MutableMapping):
         strConfiguration = {}
         for key, value in self._configuration: strConfiguration[key] = str(value)
         # save to the registry
-        MetadataRegistry.add(Metadata(MetadataKey(self._name, self._item_name), str(self._value), strConfiguration))
+        MetadataRegistry.add(Metadata(self._keyUID, str(self._value), strConfiguration))
         del strConfiguration
     
     def remove(self):
         '''Deletes this namespace from the registry.
         This instance will be preserved and can be written back to the registry.'''
-        MetadataRegistry.remove(MetadataKey(self._name, self._item_name))
+        MetadataRegistry.remove(self._keyUID)
     
     def set_value(self, value, save=True):
         '''Sets the namespace "value".

--- a/Core/automation/lib/python/core/metadata.py
+++ b/Core/automation/lib/python/core/metadata.py
@@ -1,0 +1,182 @@
+'''
+Wrapper class for using Item Metadata
+'''
+
+from collections import MutableMapping
+from org.eclipse.smarthome.core.items import Metadata, MetadataKey
+from core.log import logging, LOG_PREFIX
+log = logging.getLogger(LOG_PREFIX + ".metadata")
+from core import osgi
+MetadataRegistry = osgi.get_service("org.eclipse.smarthome.core.items.MetadataRegistry")
+
+__all__ = [ "namespace_exists", "item_metadata", "metadata_namespace" ]
+
+
+def namespace_exists(item_name, namespace):
+    '''Returns True if metadata namespace exists'''
+    return False if MetadataRegistry.get(MetadataKey(namespace, item_name)) is None else True
+
+def _resolveType(value):
+    '''Attempts to resolve the type of the metadata value.
+    It will return the value as the python type if possible,
+    otherwise will return value as string'''
+    if str(value).lower().strip() == "true":
+        return True
+    elif str(value).lower().strip() == "false":
+        return False
+    else:
+        # attempt to cast to int
+        try: return int(str(value))
+        except ValueError: pass
+        # attempt to cast to float
+        try: return float(str(value))
+        except ValueError: pass
+        # not a number
+        return str(value)
+
+class item_metadata(MutableMapping):
+    def __init__(self, item_name):
+        '''This is a manager class that can be used to manage multiple
+        metadata namespaces for a single item from one place.
+        - This class behaves like a dict of "metadata_namespace" objects.
+        - Namespaces can be added by name with "add_namespace(name)"
+        (attempting to add a namespace that already exists will raise a KeyError)'''
+        self._item_name = item_name
+        self._namespaces = {}
+
+    def __iter__(self): return iter(self._namespaces)
+    def __len__(self): return len(self._namespaces)
+    def __setitem__(self, key, value): raise AttributeError("Direct assignment to keys not possible")
+    def __getitem__(self, key): return self._namespaces[key]
+    def __delitem__(self, key): self.delete_namespace(key)
+
+    def add_namespace(self, name):
+        '''Creates a new namespace instance and loads it from the registry
+        if it exists.'''
+        if name in self._namespaces: raise KeyError
+        else: self._namespaces[name] = metadata_namespace(self._item_name ,name)
+
+    def delete_namespace(self, name, remove=False):
+        '''Deletes the specified namespace from this object. It will not
+        remove the namespace from openHAB unless the "remove" flag is set'''
+        if name not in self._namespaces: raise KeyError
+        else:
+            if remove: self._namespaces[name].remove
+            self._namespaces.pop(name, None)
+
+
+class metadata_namespace(MutableMapping):
+    def __init__(self, item_name, name, value=None, configuration={}, load=True, save=False):
+        '''Item metadata namespace
+        If "load" is set the namespace will be loaded from the registry. If it 
+        exists "value" and "configuration" will be overwritten if provided. 
+        If "save" is set the namespace will be written immediately to the 
+        registry. This will overwrite the namespace if it exists already. 
+        If the "load" flag is set the "save" flag will be ignored.'''
+        log.debug("Metadata: Initializing namespace object for item '{item}' namespace '{namespace}'".format( \
+            item=item_name, namespace=name))
+        self._item_name = item_name
+        self._name = name
+        self._value = value
+        self._configuration = configuration
+        if load: 
+            log.debug("Metadata: Load on initialize for item '{item}' namespace '{namespace}'".format( \
+                item=item_name, namespace=name))
+            self.load()
+        elif save:
+            log.debug("Metadata: Save on initialize for item '{item}' namespace '{namespace}' with value '{value}' and configuration'{configuration}'".format( \
+                item=item_name, namespace=name, value=str(value), configuration=str(configuration)))
+            self.save()
+    
+    def __iter__(self): return iter(self._configuration)
+    def __len__(self): return len(self._configuration)
+    def __setitem__(self, key, value): return self.set_config_value(key, value)
+    def __getitem__(self, key): return self.get_config_value(key)
+    def __delitem__(self, key): self.delete_config_value(key)
+
+    def load(self):
+        '''Loads the namespace from the metadata registry.
+        THIS WILL OVERWRITE ANY UNSAVED CHANGES TO THIS INSTANCE!'''
+        log.debug("Metadata: Getting metadata for item '{item}' from namespace '{namespace}'".format( \
+            item=self._item_name, namespace=self._name))
+        # read from registry
+        metadata = MetadataRegistry.get(MetadataKey(self._name, self._item_name))
+        log.debug("Metadata: {metadata}".format( \
+            metadata=str(metadata)))
+        # parse data
+        if metadata is not None: # namespace exists
+            self._value = _resolveType(metadata.value)
+            # load all configuration items into namespace dict
+            self._configuration = {}
+            for key, value in metadata.configuration.iteritems():
+                self._configuration[str(key)] = _resolveType(value)
+
+    def save(self):
+        '''Saves the namespace to the metadata registry.
+        (This is done automatically when changes to the value or configuration are made
+        unless the "save" flag was set to false when making those changes)'''
+        # convert all values to strings
+        strConfiguration = {}
+        for key, value in self._configuration: strConfiguration[key] = str(value)
+        # save to the registry
+        MetadataRegistry.add(Metadata(MetadataKey(self._name, self._item_name), str(self._value), strConfiguration))
+        del strConfiguration
+    
+    def remove(self):
+        '''Deletes this namespace from the registry.
+        This instance will be preserved and can be written back to the registry.'''
+        MetadataRegistry.remove(MetadataKey(self._name, self._item_name))
+    
+    def set_value(self, value, save=True):
+        '''Sets the namespace "value".
+        Set "save" flag to False to skip saving to openHAB. You must take care to manually save
+        using the "save()" method or setting another element with the "save" flag set to True.'''
+        self._value = value
+        if save: self.save()
+
+    def get_value(self):
+        '''Gets the namespace "value".'''
+        return self._value
+
+    def set_config_value(self, key, value, save=True):
+        '''Sets the namespace configuration value for the specified key.
+        You can also use the dict method "metadata_namespace[key] = value"
+        Set "save" flag to False to skip saving to openHAB. You must take care to manually save
+        using the "save()" method or setting another element with the "save" flag set to True.'''
+        self._configuration[str(key)] = value
+        if save: self.save()
+
+    def get_config_value(self, key):
+        '''Gets the value for the specified configuration key.
+        You can also use the dict method "value = metadata_namespace[key]"'''
+        return self._configuration.get(str(key))
+
+    def delete_config_value(self, key, save=True):
+        '''Deletes the specified key from the configuration.
+        You can also use the dict method "del metadata_namespace[key]"
+        Set "save" flag to False to skip saving to openHAB. You must take care to manually save
+        using the "save()" method or setting another element with the "save" flag set to True.'''
+        self._configuration.pop(str(key), None)
+        if save: self.save()
+
+    def set_configuration(self, configuration, save=True):
+        '''Allows setting the entire configuration dict.
+        THIS WILL OVERWRITE THE EXISTING CONFIGURATION DICT!
+        Set "save" flag to False to skip saving to openHAB. You must take care to manually save
+        using the "save()" method or setting another element with the "save" flag set to True.'''
+        if not isinstance(configuration, dict): raise TypeError
+        self._configuration = configuration
+
+    def add_configuration(self, configuration, save=True):
+        '''Allows adding an iterable list or dict of new key-value pairs to the configuration.
+        Set "save" flag to False to skip saving to openHAB. You must take care to manually save
+        using the "save()" method or setting another element with the "save" flag set to True.'''
+        self._configuration.update(configuration)
+        if save: self.save()
+
+    def clear_configuration(self, save=True):
+        '''Clears all keys and values in the configuration dict.
+        Set "save" flag to False to skip saving to openHAB. You must take care to manually save
+        using the "save()" method or setting another element with the "save" flag set to True.'''
+        self._configuration = {}
+        if save: self.save()

--- a/Docs/Jython-Modules.md
+++ b/Docs/Jython-Modules.md
@@ -208,8 +208,10 @@ metadata_namespace(item_name, name, value=None, configuration={}, load=True, sav
 metadata_namespace.load()
 metadata_namespace.save()
 metadata_namespace.remove()
-metadata_namespace.set_value(value)
+metadata_namespace.set_value(value, save=True)
+metadata_namespace.value = value # same as above
 metadata_namespace.get_value()
+value = metadata_namespace.value # same as above
 metadata_namespace.set_config_value(key, value, save=True)
 metadata_namespace[key] = value # same as above
 metadata_namespace.get_config_value(key)
@@ -221,7 +223,7 @@ metadata_namespace.add_configuration(configuration, save=True)
 metadata_namespace.clear_configuration(save=True)
 ```
 
-__`item_metadata`__ is used to manage multiple namespaces for a single item using only one object. It can be used similar to a python `dict` containing instances of `metadata_namespace`. Below is a list of all the methods, detailed descriptions can be found at the beginning of each on in the code.
+__`item_metadata`__ is used to manage multiple namespaces for a single item using only one object. It can be used similar to a python `dict` containing instances of `metadata_namespace`. Below is a list of all the methods, detailed descriptions can be found at the beginning of each one in the code.
 ```python
 item_metadata(item_name)
 item_metadata.add_namespace(name)

--- a/Docs/Jython-Modules.md
+++ b/Docs/Jython-Modules.md
@@ -197,6 +197,41 @@ core.link.remove_link("Kodi_Control")
 ```
 </ul>
 
+#### Module: [`core.metadata`](..Core/automation/lib/python/core/metadata.py)
+<ul>
+
+This module allows simpler interaction with item metadata. There are two instance classes that can be used manage a single namespace, or multiple namespaces of a single item.
+
+__`metadata_namespace`__ is used to manage a single namespace. It can be used like a python `dict` to get and set key-value pairs in the namespace configuration. It will attempt to convert the namespace and configuration values to a `bool`, `float`, or `int` when loading from the registry. Below is a list of all of the methods, detailed descriptions can be found at the beginning of each one in the code.
+```python
+metadata_namespace(item_name, name, value=None, configuration={}, load=True, save=False)
+metadata_namespace.load()
+metadata_namespace.save()
+metadata_namespace.remove()
+metadata_namespace.set_value(value)
+metadata_namespace.get_value()
+metadata_namespace.set_config_value(key, value, save=True)
+metadata_namespace[key] = value # same as above
+metadata_namespace.get_config_value(key)
+value = metadata_namespace[key] # same as above
+metadata_namespace.delete_config_value(key, save=True)
+del metadata_namespace[key] # same as above
+metadata_namespace.set_configuration(configuration, save=True)
+metadata_namespace.add_configuration(configuration, save=True)
+metadata_namespace.clear_configuration(save=True)
+```
+
+__`item_metadata`__ is used to manage multiple namespaces for a single item using only one object. It can be used similar to a python `dict` containing instances of `metadata_namespace`. Below is a list of all the methods, detailed descriptions can be found at the beginning of each on in the code.
+```python
+item_metadata(item_name)
+item_metadata.add_namespace(name)
+item_metadata[name] # returns metadata_namespace object
+item_metadata.delete_namespace(name, remove=False)
+del item_metadata[name] # same as above
+```
+
+</ul>
+
 #### Module: [`core.testing`](../Core/automation/lib/python/core/testing.py)
 <ul>
 

--- a/Docs/Jython-Modules.md
+++ b/Docs/Jython-Modules.md
@@ -200,30 +200,65 @@ core.link.remove_link("Kodi_Control")
 #### Module: [`core.metadata`](..Core/automation/lib/python/core/metadata.py)
 <ul>
 
-This module allows simpler interaction with item metadata. There are two instance classes that can be used manage a single namespace, or multiple namespaces of a single item.
+This module allows simpler interaction with item metadata.
+There are two instance classes that can be used manage a single namespace, or multiple namespaces of a single item.
 
-__`metadata_namespace`__ is used to manage a single namespace. It can be used like a python `dict` to get and set key-value pairs in the namespace configuration. It will attempt to convert the namespace and configuration values to a `bool`, `float`, or `int` when loading from the registry. Below is a list of all of the methods, detailed descriptions can be found at the beginning of each one in the code.
+__`metadata_namespace`__ is used to manage a single namespace.
+It can be used like a python `dict` to get and set key-value pairs in the namespace configuration.
+It will attempt to convert the namespace and configuration values to a `bool`, `float`, or `int` when loading from the registry.
+
 ```python
-metadata_namespace(item_name, name, value=None, configuration={}, load=True, save=False)
-metadata_namespace.load()
-metadata_namespace.save()
-metadata_namespace.remove()
-metadata_namespace.set_value(value, save=True)
-metadata_namespace.value = value # same as above
-metadata_namespace.get_value()
-value = metadata_namespace.value # same as above
-metadata_namespace.set_config_value(key, value, save=True)
-metadata_namespace[key] = value # same as above
-metadata_namespace.get_config_value(key)
-value = metadata_namespace[key] # same as above
-metadata_namespace.delete_config_value(key, save=True)
-del metadata_namespace[key] # same as above
-metadata_namespace.set_configuration(configuration, save=True)
-metadata_namespace.add_configuration(configuration, save=True)
-metadata_namespace.clear_configuration(save=True)
+from core.metadata import metadata_namespace
+
+# load existing metadata namespace from item
+test_metadata = metadata_namespace("Test_Item", "Test_Namespace")
+log.info(test_metadata.value) # print value
+for key, value in test_metadata.iteritems():
+    log.info(key + ": " + value) # print all config keys and values
+
+# create new namespace and save immediately
+new_metadata = metadata_namespace("Test_Item", "New_Namespace", value=False, load=False, save=True)
+new_metadata["New_Key"] = 100 # add new config value and save
+del new_metadata["New_Key"] # delete config value and save
+new_metadata.remove() # remove metadata namespace from registry
 ```
 
-__`item_metadata`__ is used to manage multiple namespaces for a single item using only one object. It can be used similar to a python `dict` containing instances of `metadata_namespace`. Below is a list of all the methods, detailed descriptions can be found at the beginning of each one in the code.
+Below is a list of all of the methods, detailed descriptions can be found at the beginning of each one in the code.
+
+```python
+metadata_namespace(item_name, name, value=None, configuration={}, load=True, save=False)
+metadata_namespace.load() # manually load from registry
+metadata_namespace.save() # manually save to registry
+metadata_namespace.remove() # delete namespace from registry
+metadata_namespace.set_value(value, save=True) # set namespace value
+metadata_namespace.value = value # same as above
+metadata_namespace.get_value() # get namespace value
+value = metadata_namespace.value # same as above
+metadata_namespace.set_config_value(key, value, save=True) # set configuration value
+metadata_namespace[key] = value # same as above
+metadata_namespace.get_config_value(key) # get configuration value
+value = metadata_namespace[key] # same as above
+metadata_namespace.delete_config_value(key, save=True) # delete configuration value
+del metadata_namespace[key] # same as above
+metadata_namespace.set_configuration(configuration, save=True) # set the passed dict as the configuration dict
+metadata_namespace.add_configuration(configuration, save=True) # adds the passed dict or list to configuration dict
+metadata_namespace.clear_configuration(save=True) # deletes the configuration dict
+```
+
+__`item_metadata`__ is used to manage multiple namespaces for a single item using only one object.
+It can be used similar to a python `dict` containing instances of `metadata_namespace`.
+
+```python
+from core.metadata import item_metadata
+
+test_item_metadata = item_metadata("Test_Item") # create object
+test_item_metadata.add_namespace("Test_Namespace") # add namespace
+test_item_metadata["Test_Namespace"]["New_Key"] = 42 # add configuration value to "Test_Namespace"
+test_item_metadata.delete_namespace("Test_Namespace", remove=True) # remove metadata namespace from registry and object
+```
+
+Below is a list of all the methods, detailed descriptions can be found at the beginning of each one in the code.
+
 ```python
 item_metadata(item_name)
 item_metadata.add_namespace(name)


### PR DESCRIPTION
As I mentioned, metadata classes!

@openhab-5iver I don't have write access on #61 so I couldn't push to that branch. I figured since mine differs so much from that one I would start my own branch and PR for it.

@mjcumming Credit where credit is due Michael, I started writing this module with your code in #61 as a reference point and it was a great help as I had not done anything with metadata before this. I found your class to be rather raw in that you always manually read and write to the registry. I moved to a more hands off approach where the class immediately loads when created and writes when any changes are made. My `metadata_namespace` class loosely resembles your class, and I added another simple class to allow managing multiple namespaces of a single item from one object.

&nbsp;
> and a provider should be used (which I think I wrote already).

I forgot you had mentioned this until I was looking at the other PR to compose this message. I don't see anything metadata in the codebase. 
Presently I am not using a Provider, but I found the code in OH Core. I will look into this more, though at present I'm not entirely sure it's necessary for the purposes of this class. As I understand it, the Provider allows OH to know what attributes a namespace should have, but that seems beyond the scope of this module as it stands.
I could create a Provider that would allow adding namespace definitions from JSR223 code, this would be useful for what I am getting into as it would allow changes to the namespaces from PaperUI.