### PR TITLE
Correcting hyperlinks, typos, grammar, and example domain

### DIFF
--- a/Sphinx/Guides/Actions.rst
+++ b/Sphinx/Guides/Actions.rst
@@ -17,10 +17,10 @@ For LogAction, see :doc:`Logging`.
         .. code-block::
 
             from core.actions import Exec
-            Exec.executeCommandLine("/bin/sh@@-c@@/usr/bin/curl -s --connect-timeout 3 --max-time 3 http://some.host.name",5000)
+            Exec.executeCommandLine("/bin/sh@@-c@@/usr/bin/curl -s --connect-timeout 3 --max-time 3 http://host.example.com",5000)
 
             from core.actions import HTTP
-            HTTP.sendHttpPutRequest("someURL.com, "application/json", '{"this": "that"}')
+            HTTP.sendHttpPutRequest("someURL.example.com, "application/json", '{"this": "that"}')
 
             from core.actions import Ping
             if Ping.checkVitality("10.5.5.5", 0, 5000):
@@ -31,11 +31,11 @@ For LogAction, see :doc:`Logging`.
             from core.actions import Audio
             Audio.playSound("doorbell.mp3")# using the default audiosink
             Audio.playSound("my:audio:sink", "doorbell.mp3")# specifying an audiosink
-            Audio.playStream("http://myAudioServer/myAudioFile.mp3")# using the default audiosink
-            Audio.playStream("my:audio:sink", "http://myAudioServer/myAudioFile.mp3")# specifying an audiosink
+            Audio.playStream("http://myAudioServer.example.com/myAudioFile.mp3")# using the default audiosink
+            Audio.playStream("my:audio:sink", "http://myAudioServer.example.com/myAudioFile.mp3")# specifying an audiosink
 
             from core.actions import NotificationAction
-            NotificationAction.sendNotification("someone@someDomain.com","This is the message")
+            NotificationAction.sendNotification("someone@example.com","This is the message")
             NotificationAction.sendBroadcastNotification("This is the message")
             NotificationAction.sendLogNotification("This is the message")
 
@@ -125,7 +125,7 @@ Use an Addon/Bundle Action
         .. code-block::
 
             from core.actions import Mail
-            Mail.sendMail("someone@someDomain.com", "This is the subject", "This is the message")
+            Mail.sendMail("someone@example.com", "This is the subject", "This is the message")
 
         `Astro <https://www.openhab.org/addons/actions/astro/#astro-actions>`_
 

--- a/Sphinx/Guides/Event Object Attributes.rst
+++ b/Sphinx/Guides/Event Object Attributes.rst
@@ -7,7 +7,7 @@ The specific data depends on the event type.
 For example, the ``event`` object returned by the `ItemStateChangedEvent <https://github.com/openhab/openhab-core/blob/master/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemStateChangedEvent.java>`_ event type has ``itemName``, ``itemState``, and ``oldItemState`` attributes. The ``StartupTrigger`` and ``GenericCronTrigger`` do not provide any ``event`` objects.
 Rather than digging through the code to look up the attributes available in a particular ``event`` object, you can add a log entry inside the function and then trigger the rule (:ref:`Guides/But How Do I:View the names of an object's attributes`).
 
-Here is a table of the attributes available in ``event`` objects (or ``inputs['event']``, if using aaw API or extensions), including a comparison to the Rules DSL implicit variables:
+Here is a table of the attributes available in ``event`` objects (or ``inputs['event']``, if using raw API or extensions), including a comparison to the Rules DSL implicit variables:
 
 +--------------------------+--------------------------+-------------------------------+----------------------------------+-----------------------------------------------+
 | Rules DSL Equivalent     | Scripted Automation      | @when Trigger(s)              | Event Object(s)                  | Description                                   |
@@ -72,10 +72,12 @@ Here is a table of the attributes available in ``event`` objects (or ``inputs['e
 .. _ItemCommandEvent: https://github.com/openhab/openhab-core/blob/master/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemCommandEvent.java
 .. _ItemStatePredictedEvent: https://github.com/openhab/openhab-core/blob/master/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemStatePredictedEvent.java
 .. _GroupItemStateChangedEvent: https://github.com/openhab/openhab-core/blob/master/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/events/GroupItemStateChangedEvent.java
-.. _ItemAddedEvent: https://github.com/openhab/openhab-core/blob/master/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemAddedEvent.java), [ItemRemovedEvent](https://github.com/openhab/openhab-core/blob/master/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemRemovedEvent.java
+.. _ItemAddedEvent: https://github.com/openhab/openhab-core/blob/master/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemAddedEvent.java
+.. _ItemRemovedEvent: (https://github.com/openhab/openhab-core/blob/master/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemRemovedEvent.java
 .. _ItemUpdatedEvent: https://github.com/openhab/openhab-core/blob/master/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemUpdatedEvent.java
 .. _ChannelTriggeredEvent: https://github.com/openhab/openhab-core/blob/master/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/events/ChannelTriggeredEvent.java
-.. _ThingAddedEvent: https://github.com/openhab/openhab-core/blob/master/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/events/ThingAddedEvent.java), [ThingRemovedEvent](https://github.com/openhab/openhab-core/blob/master/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/events/ThingRemovedEvent.java
+.. _ThingAddedEvent: https://github.com/openhab/openhab-core/blob/master/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/events/ThingAddedEvent.java
+.. _ThingRemovedEvent: https://github.com/openhab/openhab-core/blob/master/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/events/ThingRemovedEvent.java
 .. _ThingUpdatedEvent: https://github.com/openhab/openhab-core/blob/master/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/events/ThingUpdatedEvent.java
 .. _ThingStatusInfoEvent: https://github.com/openhab/openhab-core/blob/master/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/events/ThingStatusInfoEvent.java
 .. _ThingStatusInfoChangedEvent: https://github.com/openhab/openhab-core/blob/master/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/events/ThingStatusInfoChangedEvent.java

--- a/Sphinx/Guides/Logging.rst
+++ b/Sphinx/Guides/Logging.rst
@@ -6,7 +6,7 @@ The helper libraries provide several ways to produce log output in openHAB.
 This can be useful for providing information or error messages from your scripts to help diagnose issues.
 In some of the following examples, the logger can be modified to wherever you want the log to go.
 The default logger used in the modules and scripts is 'jsr223.<language name>', which is pulled from the value assigned to the LOG_PREFIX variable in the configuration library.
-If this is modified, be sure to `configure your logging <https://www.openhab.org/docs/administration/logging.html#logging-in-openhab>` to include the logger chosen.
+If this is modified, be sure to `configure your logging <https://www.openhab.org/docs/administration/logging.html#logging-in-openhab>`_ to include the logger chosen.
 
 
 Rule Decorator

--- a/Sphinx/Guides/Rules.rst
+++ b/Sphinx/Guides/Rules.rst
@@ -4,18 +4,18 @@ Rules
 
 One of the primary use cases for JSR223 scripting in openHAB is to define rules for the `Next-Generation Rule Engine`_ using the `Automation API`_.
 The rule engine structures rules with *Modules* (Triggers, Conditions, Actions).
-Modules are further broken down into *ModuleTypes* with cooresponding *ModuleHandlers*.
+Modules are further broken down into *ModuleTypes* with corresponding *ModuleHandlers*.
 Scripted rules can use ModuleTypes that are already present in openHAB, and also define new ones that can be used outside of the scripting language that defined it, including rules created in the UI.
 
 .. _Next-Generation Rule Engine: https://www.openhab.org/docs/configuration/rules-ng.html
 .. _Automation API: http://www.eclipse.org/smarthome/documentation/features/rules.html#java-api
 
-When a script is loaded, it is provided with a *JSR223 scope* that `predefines a number of variables <https://www.openhab.org/docs/configuration/jsr223.html#default-variables-no-preset-loading-required>`.
+When a script is loaded, it is provided with a *JSR223 scope* that `predefines a number of variables <https://www.openhab.org/docs/configuration/jsr223.html#default-variables-no-preset-loading-required>`_.
 These include the most commonly used core types and values from openHAB (e.g., State, Command, OnOffType, etc.).
 This means you don't need an import statement to load them.
 
 For defining rules, additional symbols must be defined.
-Rather than using an import, these additional symbols (`presets <https://www.openhab.org/docs/configuration/jsr223.html#predefined-script-variables-all-jsr223-languages>`) are imported using:
+Rather than using an import, these additional symbols (`presets <https://www.openhab.org/docs/configuration/jsr223.html#predefined-script-variables-all-jsr223-languages>`_) are imported using:
 
 .. code-block::
 
@@ -46,7 +46,7 @@ Decorators
 ==========
 
 The easiest way to write rules, and the most familiar if you have used the openHAB rules DSL, is using the decorators provided by this library.
-`Decorators <https://wiki.python.org/moin/PythonDecorators>` are part of the Python language and allow you to modify, or "decorate", a function, method or class.
+`Decorators <https://wiki.python.org/moin/PythonDecorators>_` are part of the Python language and allow you to modify, or "decorate", a function, method or class.
 The libraries provide a decorator called ``rule`` for defining rules and another called ``when`` for adding triggers to rules.
 This section will show you how to define rules and triggers, and it will also compare their usage with the syntax of the rules DSL to help with migration.
 

--- a/Sphinx/Guides/Triggers.rst
+++ b/Sphinx/Guides/Triggers.rst
@@ -161,7 +161,7 @@ Cron
 ====
 
     Cron triggers can be used to trigger rules at specific times.
-    There are a few built-in expressions, their use is shown in the examples.
+    There are a few built-in expressions; their use is shown in the examples.
     Several tools are available to help with composing cron expressions such as `CronMaker`_ or `FreeFormatter`_.
     More information can be found in the `openHAB documentation`_.
 


### PR DESCRIPTION
This pull request corrects formatting to render some hyperlinks, fixes some typographical / grammatical errors, and uses the RFC 2606 reserved domain name "example.com". 