### PR TITLE
JS backwards compatibility

### DIFF
--- a/Core/automation/lib/javascript/core/utils.js
+++ b/Core/automation/lib/javascript/core/utils.js
@@ -13,8 +13,17 @@
 	//https://wiki.shibboleth.net/confluence/display/IDP30/ScriptedAttributeDefinition
 	var logger 					= Java.type("org.slf4j.LoggerFactory").getLogger("jsr223.javascript");
 	
-	var RuleBuilder 			= Java.type("org.openhab.core.automation.util.RuleBuilder");
-	var RuleManager 			= Java.type("org.openhab.core.automation.RuleManager");
+	try {
+		var RuleBuilder = Java.type("org.openhab.core.automation.util.RuleBuilder");
+	} catch(e) {
+		var RuleBuilder = Java.type("org.eclipse.smarthome.automation.core.util.RuleBuilder");
+	}
+	
+	try {
+		var RuleManager = Java.type("org.openhab.core.automation.RuleManager");
+	} catch(e) {
+		var RuleManager = Java.type("org.eclipse.smarthome.automation.RuleManager");
+	}
 
 	var uuid 					= Java.type("java.util.UUID");
 	var ScriptExecution 		= Java.type("org.eclipse.smarthome.model.script.actions.ScriptExecution");


### PR DESCRIPTION
This adds backwards compatibility to core.utils for OH 2.4. There are some other classes that worry me, but they will get cleaned up as the libraries get built out.

Signed-off-by: Scott Rushworth <openhab@5iver.com>