### PR TITLE
Update testing_example.py

### DIFF
--- a/Script Examples/Python/testing_example.py
+++ b/Script Examples/Python/testing_example.py
@@ -38,7 +38,6 @@ class MyUnitTest(unittest.TestCase):
     ITEM1NAME = "TestNumber1"
     ITEM2NAME = "TestNumber2"
 
-
     def setUp(self):
         self.item1 = core.items.add_item(self.ITEM1NAME, "Number")
         self.item2 = core.items.add_item(self.ITEM2NAME, "Number")

--- a/Script Examples/Python/testing_example.py
+++ b/Script Examples/Python/testing_example.py
@@ -1,12 +1,12 @@
 """
-Examples of unit testing.
+Example of unit testing.
 """
 import unittest
 import time
 import core.items
 from core.log import logging, LOG_PREFIX
 from core.rules import rule
-from core.testing import _run_test
+from core.testing import run_test
 from core.triggers import when
 from core.utils import getItemValue, postUpdateCheckFirst
 
@@ -28,11 +28,8 @@ class ItemPostUpdater(object):
     def __call__(self, event):
         log.debug("rule {} triggered by {}, state {}".format(self.__class__.__name__, event.itemName, event.itemState))
         events.postUpdate(self.item2.name, str(2 * getItemValue(self.item1.name, 0.1)))
-    
+
     def cleanup(self):
-        #get_automation_manager().removeRule(rule)
-        #log.info(self.myrule)
-        #log.info(dir(self.myrule))
         pass
 
 class MyUnitTest(unittest.TestCase):
@@ -61,6 +58,4 @@ class MyUnitTest(unittest.TestCase):
 # results are a JSON formatted string (will probably change to return Python dict instead)
 
 def scriptLoaded(id):
-    log.info("testing_2_example.py Unittest: [{}]".format(5 + 5))
-    log.info(_run_test(MyUnitTest))
-
+    log.info(run_test(MyUnitTest))

--- a/Script Examples/Python/testing_example.py
+++ b/Script Examples/Python/testing_example.py
@@ -53,6 +53,7 @@ class MyUnitTest(unittest.TestCase):
         time.sleep(RESPONSE_TIME)
         self.assertEqual(self.item2.state.floatValue(), 10.0)
 
+
 # results are also logged to the openHAB log file
 # status can be used to take actions like sending notifications
 # results are a JSON formatted string (will probably change to return Python dict instead)

--- a/Script Examples/Python/testing_example.py
+++ b/Script Examples/Python/testing_example.py
@@ -59,4 +59,4 @@ class MyUnitTest(unittest.TestCase):
 # results are a JSON formatted string (will probably change to return Python dict instead)
 
 def scriptLoaded(id):
-    log.info(run_test(MyUnitTest))
+    log.info(run_test(MyUnitTest))    

--- a/Script Examples/Python/testing_example.py
+++ b/Script Examples/Python/testing_example.py
@@ -29,7 +29,6 @@ class ItemPostUpdater(object):
         log.debug("rule {} triggered by {}, state {}".format(self.__class__.__name__, event.itemName, event.itemState))
         events.postUpdate(self.item2.name, str(2 * getItemValue(self.item1.name, 0.1)))
 
-
     def cleanup(self):
         pass
 

--- a/Script Examples/Python/testing_example.py
+++ b/Script Examples/Python/testing_example.py
@@ -3,6 +3,7 @@ Examples of unit testing.
 """
 import unittest
 import time
+import core.items
 from core.log import logging, LOG_PREFIX
 from core.rules import rule
 from core.testing import _run_test

--- a/Script Examples/Python/testing_example.py
+++ b/Script Examples/Python/testing_example.py
@@ -32,6 +32,7 @@ class ItemPostUpdater(object):
     def cleanup(self):
         pass
 
+
 class MyUnitTest(unittest.TestCase):
 
     ITEM1NAME = "TestNumber1"

--- a/Script Examples/Python/testing_example.py
+++ b/Script Examples/Python/testing_example.py
@@ -29,6 +29,7 @@ class ItemPostUpdater(object):
         log.debug("rule {} triggered by {}, state {}".format(self.__class__.__name__, event.itemName, event.itemState))
         events.postUpdate(self.item2.name, str(2 * getItemValue(self.item1.name, 0.1)))
 
+
     def cleanup(self):
         pass
 

--- a/Script Examples/Python/testing_example.py
+++ b/Script Examples/Python/testing_example.py
@@ -7,7 +7,7 @@ import core.items
 from core.jsr223 import scope, get_automation_manager
 from core.log import logging, LOG_PREFIX
 from core.rules import rule
-from core.testing import _run_test
+from core.testing import run_test
 from core.triggers import when
 from core.utils import getItemValue, postUpdateCheckFirst
 
@@ -31,16 +31,12 @@ class ItemPostUpdater(object):
         events.postUpdate(self.item2.name, str(2 * getItemValue(self.item1.name, 0.1)))
     
     def cleanup(self):
-        #get_automation_manager().removeRule(rule)
-        #log.info(self.myrule)
-        #log.info(dir(self.myrule))
         pass
 
 class MyUnitTest(unittest.TestCase):
 
     ITEM1NAME = "TestNumber1"
     ITEM2NAME = "TestNumber2"
-
 
     def setUp(self):
         self.item1 = core.items.add_item(self.ITEM1NAME, "Number")
@@ -62,6 +58,5 @@ class MyUnitTest(unittest.TestCase):
 # results are a JSON formatted string (will probably change to return Python dict instead)
 
 def scriptLoaded(id):
-    log.info("testing_2_example.py Unittest: [{}]".format(5 + 5))
-    log.info(_run_test(MyUnitTest))
+    log.info(run_test(MyUnitTest))
 

--- a/Script Examples/Python/testing_example.py
+++ b/Script Examples/Python/testing_example.py
@@ -1,19 +1,17 @@
 """
-Example of unit testing.
+Examples of unit testing.
 """
 import unittest
 import time
-import core.items
-from core.jsr223 import scope, get_automation_manager
 from core.log import logging, LOG_PREFIX
 from core.rules import rule
-from core.testing import run_test
+from core.testing import _run_test
 from core.triggers import when
 from core.utils import getItemValue, postUpdateCheckFirst
 
 RESPONSE_TIME = 5
 
-log = logging.getLogger("{}.testing_example".format(LOG_PREFIX))
+log = logging.getLogger("{}.testing_2_example".format(LOG_PREFIX))
 
 class ItemPostUpdater(object):
     def __init__(self, item1, item2):
@@ -31,12 +29,16 @@ class ItemPostUpdater(object):
         events.postUpdate(self.item2.name, str(2 * getItemValue(self.item1.name, 0.1)))
     
     def cleanup(self):
+        #get_automation_manager().removeRule(rule)
+        #log.info(self.myrule)
+        #log.info(dir(self.myrule))
         pass
 
 class MyUnitTest(unittest.TestCase):
 
     ITEM1NAME = "TestNumber1"
     ITEM2NAME = "TestNumber2"
+
 
     def setUp(self):
         self.item1 = core.items.add_item(self.ITEM1NAME, "Number")
@@ -58,5 +60,6 @@ class MyUnitTest(unittest.TestCase):
 # results are a JSON formatted string (will probably change to return Python dict instead)
 
 def scriptLoaded(id):
-    log.info(run_test(MyUnitTest))
+    log.info("testing_2_example.py Unittest: [{}]".format(5 + 5))
+    log.info(_run_test(MyUnitTest))
 


### PR DESCRIPTION
Fixes #177
1. There is only one test: the plural in the first comment is correctd to singular
1. In the current version of the library, the methods in `core.items` are `add_item()` iso `add()` and `remove_item()` iso `remove()`.
1. The repository version, when executed, comes up with a
`ValueError: when: "Item TestNumber1 received update" could not be parsed because Item "TestNumber1" is not in the ItemRegistry`
I think, this error occurs because the @when decorator is expanded before the unit test creates the items. If the creation of the Trigger is delayed, the unit test runs fine on my system.
1. The items are not required and therefore removed from the files' first comment

Feel free to change.