### PR TITLE
Fixed typo in Python example

### DIFF
--- a/docs/_sources/Guides/Rules.rst.txt
+++ b/docs/_sources/Guides/Rules.rst.txt
@@ -97,7 +97,7 @@ Imports
 
             .. code-block:: python
 
-                @rule("Rule Name", description="Optional Rule Description", tag=["Tag 1", "Tag 2"])
+                @rule("Rule Name", description="Optional Rule Description", tags=["Tag 1", "Tag 2"])
 
         .. group-tab:: JavaScript
 


### PR DESCRIPTION
It;s `tags` not `tag`

Signed off by Richard Koshak: rlkoshak@gmail.com