### PR TITLE
Fix incorrect baseurl and CNAME

### DIFF
--- a/Sphinx/conf.py
+++ b/Sphinx/conf.py
@@ -124,7 +124,7 @@ autosectionlabel_prefix_document = True
 # -- Options for HTML output -------------------------------------------------
 
 # root url for these docs, also used to make CNAME for GH Pages
-html_baseurl = "https://github.com/openhab-scripters/openhab-helper-libraries/"
+html_baseurl = "https://openhab-scripters.github.io/openhab-helper-libraries/"
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.


### PR DESCRIPTION
Fixes incorrect `html_baseurl` in `Sphinx/conf.py`. GH Pages will also stop complaining about an unacceptable/invalid CNAME, as this value is used for that as well.

Signed-off-by: Michael Murton <6764025+CrazyIvan359@users.noreply.github.com>