### PR TITLE
[utils] Rename postUpdateCheckFirst and sendCommandCheckFirst

### DIFF
--- a/Core/automation/lib/python/core/utils.py
+++ b/Core/automation/lib/python/core/utils.py
@@ -93,7 +93,7 @@ def postUpdate(itemName, newValue):
     item = scope.itemRegistry.getItem(itemName) if isinstance(itemName, basestring) else itemName
     scope.events.postUpdate(item, newValue)
 
-def postUpdateIfDifferent(itemName, newValue, sendACommand=False, floatPrecision=None):
+def post_update_if_different(itemName, newValue, sendACommand=False, floatPrecision=None):
     '''
     newValue must be of a type supported by the item
 
@@ -137,14 +137,14 @@ def postUpdateIfDifferent(itemName, newValue, sendACommand=False, floatPrecision
         return False
 
 # backwards compatibility
-postUpdateCheckFirst = postUpdateIfDifferent
+postUpdateCheckFirst = post_update_if_different
 
-def sendCommandIfDifferent(itemName, newValue, floatPrecision=None):
+def send_command_if_different(itemName, newValue, floatPrecision=None):
     ''' See postUpdateCheckFirst '''
     return postUpdateCheckFirst(itemName, newValue, sendACommand=True, floatPrecision=floatPrecision)
 
 # backwards compatibility
-sendCommandCheckFirst = sendCommandIfDifferent
+sendCommandCheckFirst = send_command_if_different
 
 def validate_item(item_or_item_name):# returns Item or None
     item = item_or_item_name

--- a/Core/automation/lib/python/core/utils.py
+++ b/Core/automation/lib/python/core/utils.py
@@ -93,7 +93,7 @@ def postUpdate(itemName, newValue):
     item = scope.itemRegistry.getItem(itemName) if isinstance(itemName, basestring) else itemName
     scope.events.postUpdate(item, newValue)
 
-def postUpdateCheckFirst(itemName, newValue, sendACommand=False, floatPrecision=None):
+def postUpdateIfDifferent(itemName, newValue, sendACommand=False, floatPrecision=None):
     '''
     newValue must be of a type supported by the item
 
@@ -136,9 +136,15 @@ def postUpdateCheckFirst(itemName, newValue, sendACommand=False, floatPrecision=
         log.warn("[{}] is not an accepted {} for [{}]".format(newValue, "command type" if sendACommand else "state", item.name))
         return False
 
-def sendCommandCheckFirst(itemName, newValue, floatPrecision=None):
+# backwards compatibility
+postUpdateCheckFirst = postUpdateIfDifferent
+
+def sendCommandIfDifferent(itemName, newValue, floatPrecision=None):
     ''' See postUpdateCheckFirst '''
     return postUpdateCheckFirst(itemName, newValue, sendACommand=True, floatPrecision=floatPrecision)
+
+# backwards compatibility
+sendCommandCheckFirst = sendCommandIfDifferent
 
 def validate_item(item_or_item_name):# returns Item or None
     item = item_or_item_name


### PR DESCRIPTION
Updates names of `postUpdateCheckFirst` and `sendCommandCheckFirst` to `postUpdateIfDifferent` and `sendCommandIfDifferent`. The old names are not very clear about the use of the function. The original names have been preserved as aliases for backwards compatibility.

Fixes #185 

Signed-off-by: Mike Murton <6764025+CrazyIvan359@users.noreply.github.com>