### PR TITLE
Add missing docs page for `core.utils.py`

### DIFF
--- a/Sphinx/Python/Core/Packages and Modules/utils.rst
+++ b/Sphinx/Python/Core/Packages and Modules/utils.rst
@@ -1,0 +1,5 @@
+utils
+-----
+
+.. automodule:: core.utils
+    :members:


### PR DESCRIPTION
Adds `utils.rst` file to docs so that docstrings from `core.utils` are parsed and included in the documentation. This page was previously missing when the `utils` module was added.

Fixes #187 

Signed-off-by: Michael Murton <6764025+CrazyIvan359@users.noreply.github.com>