### PR TITLE
Add thing status triggers

### DIFF
--- a/Core/automation/lib/python/core/triggers.py
+++ b/Core/automation/lib/python/core/triggers.py
@@ -1,56 +1,54 @@
 """
-This module includes trigger subclasses and function decorators to simplify 
+This module includes trigger subclasses and function decorators to simplify
 Jython rule definitions.
 
 Trigger classes for wrapping Automation API (see :ref:`Guides/Rules:Extensions`
 for more details):
 
-* **ItemStateChangeTrigger**
-* **ItemStateUpdateTrigger**
-* **ItemCommandTrigger**
-* **ItemEventTrigger** (based on "core.GenericEventTrigger")
-* **CronTrigger**
-* **StartupTrigger** - fires when rule is activated (implemented in Jython)
-* **DirectoryEventTrigger** - fires when directory contents change (Jython, see
-  related component for more info)
-* **ItemAddedTrigger** - fires when rule is added to the RuleRegistry
-  (implemented in Jython)
-* **ItemRemovedTrigger** - fires when rule is removed from the RuleRegistry
-  (implemented in Jython)
-* **ItemUpdatedTrigger** - fires when rule is updated in the RuleRegistry
-  (implemented in Jython, not a state update!)
-* **ChannelEventTrigger** - fires when a Channel gets an event e.g. from the
-  Astro Binding
+* **ItemStateChangeTrigger** - fires when the specified Item's state changes
+* **ItemStateUpdateTrigger** - fires when the specified Item's state is updated
+* **ItemCommandTrigger** - fires when the specified Item receives a Command
+* **ThingStatusChangeTrigger** - fires when the specified Thing's status changes
+* **ThingStatusUpdateTrigger** - fires when the specified Thing's status is updated
+* **ChannelEventTrigger** - fires when a Channel reports an event
+* **CronTrigger** - fires based on cron expression
+* **GenericEventTrigger** - fires when the specified occurs
+* **ItemEventTrigger** (based on "GenericEventTrigger")
+* **ThingEventTrigger** - fires when a Thing reports an event
+* **DirectoryEventTrigger** - fires when directory contents change
+* **ItemRegistryTrigger** - fires when the specified Item event occurs
+* **ItemAddedTrigger** (based on "ItemRegistryTrigger")
+* **ItemRemovedTrigger** (based on "ItemRegistryTrigger")
+* **ItemUpdatedTrigger** (based on "ItemRegistryTrigger")
+* **StartupTrigger** - fires when the rule is activated (implemented in Jython)
 
-Trigger function decorator (see :ref:`Guides/Rules:Decorators` for more
-details):
+The ``when`` decorator simplifies many of these triggers and allows for them
+to be used with natural language, as used in the rules DSL.
+(see :ref:`Guides/Rules:Decorators` for more details).
 
 .. code-block::
 
+    @when("Time cron 55 55 5 * * ?")
     @when("Item Test_Switch_1 received command OFF")
     @when("Item Test_Switch_2 received update ON")
-    @when("Member of gMotion_Sensors changed to OFF")
-    @when("Descendent of gContact_Sensors changed to ON")
-    @when("Thing kodi:kodi:familyroom changed") #Thing statuses cannot currently be used in triggers
+    @when("Item Test_String_1 changed from 'old test string' to 'new test string'")
+    @when("Item gMotion_Sensors changed")
+    @when("Member of gMotion_Sensors changed from ON to OFF")
+    @when("Descendent of gContact_Sensors changed from OPEN to CLOSED")
+    @when("Thing kodi:kodi:familyroom changed from ONLINE to OFFLINE")
+    @when("Thing kodi:kodi:familyroom received update ONLINE")
     @when("Channel astro:sun:local:eclipse#event triggered START")
-    @when("System started") #'System started' requires S1566 or newer, and 'System shuts down' is not available
-    @when("55 55 5 * * ?")
+    @when("System started")# requires S1566 or newer ('System shuts down' has not been implemented)
 
-As a workaround for 'System started', add the rule function directly to the
-script. Here is an example that can be used with the function from the
-hello_world.py example script...
-
-.. code-block:: python
-
-    helloWorldCronDecorators(None)
+    If using a build of openHAB prior to S1566, see :ref:`Guides/Triggers:System Started` for a ``System started`` workaround.
+    For everyone, see :ref:`Guides/Triggers:System Shuts Down` for a method of executing a function when a script is unloaded, symulating a ``System shuts down`` trigger.
 """
 
-from core.jsr223 import scope
-scope.scriptExtension.importPreset(None)
+from core.jsr223.scope import itemRegistry, things, scriptExtension
+scriptExtension.importPreset(None)# fix for Jython > 2.7.0
 
 import inspect
 import json
-import uuid
 from shlex import split
 
 import java.util
@@ -89,16 +87,16 @@ from org.quartz.CronExpression import isValidExpression
 log = logging.getLogger("{}.core.triggers".format(LOG_PREFIX))
 
 class ItemStateUpdateTrigger(Trigger):
-    """Builds an ItemStateUpdateTrigger Module to be used when creating a Rule.
+    """
+    This class builds an ItemStateUpdateTrigger Module to be used when creating a Rule.
 
-    See :ref:`Guides/Rules:Extensions` for examples of how to use these 
-    extensions
+    See :ref:`Guides/Rules:Extensions` for examples of how to use these extensions.
 
     Examples:
         .. code-block::
 
-            MyRule.triggers = [ItemStateUpdateTrigger("MyItem", "ON", "MyItem_received_update_ON").trigger]
-            MyRule.triggers.append(ItemStateUpdateTrigger("MyOtherItem").trigger)
+            MyRule.triggers = [ItemStateUpdateTrigger("MyItem", "ON", "MyItem-received-update-ON").trigger]
+            MyRule.triggers.append(ItemStateUpdateTrigger("MyOtherItem", "OFF", "MyOtherItem-received-update-OFF").trigger)
 
     Args:
         itemName (str): Name of item to watch for updates
@@ -109,26 +107,23 @@ class ItemStateUpdateTrigger(Trigger):
         trigger (Trigger): Trigger object to be added to a Rule.
     """
     def __init__(self, itemName, state=None, triggerName=None):
-        if triggerName is None:
-            triggerName = uuid.uuid1().hex
-        else:
-            triggerName = "{}-{}".format(triggerName, uuid.uuid1().hex)
+        triggerName = validate_uid(triggerName)
         config = { "itemName": itemName }
         if state is not None:
             config["state"] = state
         self.trigger = TriggerBuilder.create().withId(triggerName).withTypeUID("core.ItemStateUpdateTrigger").withConfiguration(Configuration(config)).build()
 
 class ItemStateChangeTrigger(Trigger):
-    """Builds an ItemStateChangeTrigger Module to be used when creating a Rule.
+    """
+    This class builds an ItemStateChangeTrigger Module to be used when creating a Rule.
 
-    See :ref:`Guides/Rules:Extensions` for examples of how to use these
-    extensions
+    See :ref:`Guides/Rules:Extensions` for examples of how to use these extensions.
 
     Examples:
         .. code-block::
 
-            MyRule.triggers = [ItemStateChangeTrigger("MyItem", "OFF", "ON", "MyItem_changed_from_OFF_to_ON").trigger]
-            MyRule.triggers.append(ItemStateChangeTrigger("MyOtherItem").trigger)
+            MyRule.triggers = [ItemStateChangeTrigger("MyItem", "OFF", "ON", "MyItem-changed-from-OFF-to-ON").trigger]
+            MyRule.triggers.append(ItemStateChangeTrigger("MyOtherItem", "ON", "OFF","MyOtherItem-changed-from-ON-to-OFF").trigger)
 
     Args:
         itemName (str): Name of item to watch for changes
@@ -140,10 +135,7 @@ class ItemStateChangeTrigger(Trigger):
         trigger (Trigger): Trigger object to be added to a Rule
     """
     def __init__(self, itemName, previousState=None, state=None, triggerName=None):
-        if triggerName is None:
-            triggerName = uuid.uuid1().hex
-        else:
-            triggerName = "{}-{}".format(triggerName, uuid.uuid1().hex)
+        triggerName = validate_uid(triggerName)
         config = { "itemName": itemName }
         if state is not None:
             config["state"] = state
@@ -152,16 +144,16 @@ class ItemStateChangeTrigger(Trigger):
         self.trigger = TriggerBuilder.create().withId(triggerName).withTypeUID("core.ItemStateChangeTrigger").withConfiguration(Configuration(config)).build()
 
 class ItemCommandTrigger(Trigger):
-    """Builds an ItemCommandTrigger Module to be used when creating a Rule.
+    """
+    This class builds an ItemCommandTrigger Module to be used when creating a Rule.
 
-    See :ref:`Guides/Rules:Extensions` for examples of how to use these
-    extensions
+    See :ref:`Guides/Rules:Extensions` for examples of how to use these extensions.
 
     Examples:
         .. code-block::
 
-            MyRule.triggers = [ItemCommandTrigger("MyItem", "ON", "MyItem_received_command_ON").trigger]
-            MyRule.triggers.append(ItemCommandTrigger("MyOtherItem").trigger)
+            MyRule.triggers = [ItemCommandTrigger("MyItem", "ON", "MyItem-received-command-ON").trigger]
+            MyRule.triggers.append(ItemCommandTrigger("MyOtherItem", "OFF", "MyOtherItem-received-command-OFF").trigger)
 
     Args:
         itemName (str): Name of item to watch for commands
@@ -172,26 +164,77 @@ class ItemCommandTrigger(Trigger):
         trigger (Trigger): Trigger object to be added to a Rule
     """
     def __init__(self, itemName, command=None, triggerName=None):
-        if triggerName is None:
-            triggerName = uuid.uuid1().hex
-        else:
-            triggerName = "{}-{}".format(triggerName, uuid.uuid1().hex)
+        triggerName = validate_uid(triggerName)
         config = { "itemName": itemName }
         if command is not None:
             config["command"] = command
         self.trigger = TriggerBuilder.create().withId(triggerName).withTypeUID("core.ItemCommandTrigger").withConfiguration(Configuration(config)).build()
 
-class ChannelEventTrigger(Trigger):
-    """Builds an ChannelEventTrigger Module to be used when creating a Rule.
+class ThingStatusUpdateTrigger(Trigger):
+    """
+    This class builds a ThingStatusUpdateTrigger Module to be used when creating a Rule.
 
-    See :ref:`Guides/Rules:Extensions` for examples of how to use these
-    extensions
+    See :ref:`Guides/Rules:Extensions` for examples of how to use these extensions.
 
     Examples:
         .. code-block::
 
-            MyRule.triggers = [ChannelEventTrigger("binding:segment:segment", "MyEvent", "Channel_binding-segment-segment_MyEvent").trigger]
-            MyRule.triggers.append( ChannelEventTrigger("binding:segment:segment").trigger)
+            MyRule.triggers = [ThingStatusUpdateTrigger("kodi:kodi:familyroom", "ONLINE").trigger]
+
+    Args:
+        channelUID (str): Thing to watch for status updates
+        status (str): Trigger only when Thing is updated to this status
+        triggerName (str): Name of this trigger
+
+    Attributes:
+        trigger (Trigger): Trigger object to be added to a Rule.
+    """
+    def __init__(self, thingUID, status=None, triggerName=None):
+        triggerName = validate_uid(triggerName)
+        config = { "thingUID": thingUID }
+        if status is not None:
+            config["status"] = status
+        self.trigger = TriggerBuilder.create().withId(triggerName).withTypeUID("core.ThingStatusUpdateTrigger").withConfiguration(Configuration(config)).build()
+
+class ThingStatusChangeTrigger(Trigger):
+    """
+    This class builds a ThingStatusChangeTrigger Module to be used when creating a Rule.
+
+    See :ref:`Guides/Rules:Extensions` for examples of how to use these extensions.
+
+    Examples:
+        .. code-block::
+
+            MyRule.triggers = [ThingStatusChangeTrigger("kodi:kodi:familyroom", "ONLINE", "OFFLINE).trigger]
+
+    Args:
+        channelUID (str): Thing to watch for status changes
+        previousStatus (str): Trigger only when Thing is changed from this status
+        status (str): Trigger only when Thing is changed to this status
+        triggerName (str): Name of this trigger
+
+    Attributes:
+        trigger (Trigger): Trigger object to be added to a Rule.
+    """
+    def __init__(self, thingUID, previousStatus=None, status=None, triggerName=None):
+        triggerName = validate_uid(triggerName)
+        config = { "thingUID": thingUID }
+        if previousStatus is not None:
+            config["previousStatus"] = previousStatus
+        if status is not None:
+            config["status"] = status
+        self.trigger = TriggerBuilder.create().withId(triggerName).withTypeUID("core.ThingStatusChangeTrigger").withConfiguration(Configuration(config)).build()
+
+class ChannelEventTrigger(Trigger):
+    """
+    This class builds a ChannelEventTrigger Module to be used when creating a Rule.
+
+    See :ref:`Guides/Rules:Extensions` for examples of how to use these extensions.
+
+    Examples:
+        .. code-block::
+
+            MyRule.triggers = [ChannelEventTrigger("astro:sun:local:eclipse#event", "START", "solar-eclipse-event-start").trigger]
 
     Args:
         channelUID (str): Channel to watch for trigger events
@@ -202,60 +245,109 @@ class ChannelEventTrigger(Trigger):
         trigger (Trigger): Trigger object to be added to a Rule.
     """
     def __init__(self, channelUID, event=None, triggerName=None):
-        if triggerName is None:
-            triggerName = uuid.uuid1().hex
-        else:
-            triggerName = "{}-{}".format(triggerName, uuid.uuid1().hex)
+        triggerName = validate_uid(triggerName)
         config = { "channelUID": channelUID }
         if event is not None:
             config["event"] = event
         self.trigger = TriggerBuilder.create().withId(triggerName).withTypeUID("core.ChannelEventTrigger").withConfiguration(Configuration(config)).build()
 
 class GenericEventTrigger(Trigger):
+    """
+    This class builds a GenericEventTrigger Module to be used when creating a Rule.
+    It allows you to trigger on any event that comes through the Event Bus.
+    It's one of the the most powerful triggers, but it is also the most complicated to configure.
+
+    See :ref:`Guides/Rules:Extensions` for examples of how to use these extensions.
+
+    Examples:
+        .. code-block::
+
+            MyRule.triggers = [GenericEventTrigger("smarthome/items/Test_Switch_1/", "ItemStateEvent", "smarthome/items/*", "Test_Switch_1-received-update").trigger]
+
+    Args:
+        eventSource (str): Source to watch for trigger events
+        eventTypes (str or list): Types of events to watch
+        eventTopic (str): Topic to watch
+        triggerName (str): Name of this trigger
+
+    Attributes:
+        trigger (Trigger): Trigger object to be added to a Rule.
+    """
     def __init__(self, eventSource, eventTypes, eventTopic="smarthome/*", triggerName=None):
-        if triggerName is None:
-            triggerName = uuid.uuid1().hex
-        else:
-            triggerName = "{}-{}".format(triggerName, uuid.uuid1().hex)
+        triggerName = validate_uid(triggerName)
         self.trigger = TriggerBuilder.create().withId(triggerName).withTypeUID("core.GenericEventTrigger").withConfiguration(Configuration({
             "eventTopic": eventTopic,
             "eventSource": "smarthome/{}/".format(eventSource),
             "eventTypes": eventTypes
         })).build()
 
-'''
-Item event types:
-ITEM_UPDATE = "ItemStateEvent"
-ITEM_COMMAND = "ItemCommandEvent"
-ITEM_CHANGE = "ItemStateChangedEvent"
-GROUP_CHANGE = "GroupItemStateChangedEvent"
-'''
 class ItemEventTrigger(Trigger):
+    """
+    This class is the same as the ``GenericEventTrigger``, but simplifies it a bit for use with Items.
+    The available Item ``eventTypes`` are:
+
+    .. code-block:: none
+
+        "ItemStateEvent" (Item state update)
+        "ItemCommandEvent" (Item received Command)
+        "ItemStateChangedEvent" (Item state changed)
+        "GroupItemStateChangedEvent" (GroupItem state changed)
+
+    See :ref:`Guides/Rules:Extensions` for examples of how to use these extensions.
+
+    Examples:
+        .. code-block::
+
+            MyRule.triggers = [ItemEventTrigger("Test_Switch_1", "ItemStateEvent", "smarthome/items/*").trigger]
+
+    Args:
+        eventSource (str): Source to watch for trigger events
+        eventTypes (str or list): Types of events to watch
+        eventTopic (str): Topic to watch (no need to change default)
+        triggerName (str): Name of this trigger
+
+    Attributes:
+        trigger (Trigger): Trigger object to be added to a Rule.
+    """
     def __init__(self, eventSource, eventTypes, eventTopic="smarthome/items/*", triggerName=None):
-        if triggerName is None:
-            triggerName = uuid.uuid1().hex
-        else:
-            triggerName = "{}-{}".format(triggerName, uuid.uuid1().hex)
+        triggerName = validate_uid(triggerName)
         self.trigger = TriggerBuilder.create().withId(triggerName).withTypeUID("core.GenericEventTrigger").withConfiguration(Configuration({
             "eventTopic": eventTopic,
             "eventSource": "smarthome/items/{}/".format(eventSource),
             "eventTypes": eventTypes
         })).build()
 
-'''
-Thing event types:
-"ThingAddedEvent"
-"ThingRemovedEvent"
-"ThingStatusInfoChangedEvent"
-"ThingStatusInfoEvent"
-"ThingUpdatedEvent"
-'''
 class ThingEventTrigger(Trigger):
+    """
+    This class is the same as the ``GenericEventTrigger``, but simplifies it a bit for use with Things.
+    The available Thing ``eventTypes`` are:
+
+    .. code-block:: none
+
+        "ThingAddedEvent"
+        "ThingRemovedEvent"
+        "ThingStatusInfoChangedEvent"
+        "ThingStatusInfoEvent"
+        "ThingUpdatedEvent"
+
+    See :ref:`Guides/Rules:Extensions` for examples of how to use these extensions.
+
+    Examples:
+        .. code-block::
+
+            MyRule.triggers = [ThingEventTrigger("kodi:kodi:familyroom", "ThingStatusInfoEvent").trigger]
+
+    Args:
+        eventSource (str): Source to watch for trigger events
+        eventTypes (str or list): Types of events to watch
+        eventTopic (str): Topic to watch (no need to change default)
+        triggerName (str): Name of this trigger
+
+    Attributes:
+        trigger (Trigger): Trigger object to be added to a Rule.
+    """
     def __init__(self, thingUID, eventTypes, eventTopic="smarthome/things/*", triggerName=None):
-        if triggerName is None:
-            triggerName = uuid.uuid1().hex
-        else:
-            triggerName = "{}-{}".format(triggerName, uuid.uuid1().hex)
+        triggerName = validate_uid(triggerName)
         self.trigger = TriggerBuilder.create().withId(triggerName).withTypeUID("core.GenericEventTrigger").withConfiguration(Configuration({
             "eventTopic": eventTopic,
             "eventSource": "smarthome/things/{}/".format(thingUID),
@@ -268,74 +360,165 @@ EVERY_MINUTE = "0 * * * * ?"
 EVERY_HOUR = "0 0 * * * ?"
 
 class CronTrigger(Trigger):
+    """
+    This class builds a CronTrigger Module to be used when creating a Rule.
+
+    See :ref:`Guides/Rules:Extensions` for examples of how to use these extensions.
+
+    Examples:
+        .. code-block::
+
+            MyRule.triggers = [CronTrigger("0 55 17 * * ?").trigger]
+
+    Args:
+        cronExpression (str): A valid `cron expression <http://www.quartz-scheduler.org/documentation/quartz-2.2.2/tutorials/tutorial-lesson-06.html>`_
+        triggerName (str): Name of this trigger
+
+    Attributes:
+        trigger (Trigger): Trigger object to be added to a Rule.
+    """
     def __init__(self, cronExpression, triggerName=None):
-        if triggerName is None:
-            triggerName = uuid.uuid1().hex
-        else:
-            triggerName = "{}-{}".format(triggerName, uuid.uuid1().hex)
+        triggerName = validate_uid(triggerName)
         self.trigger = TriggerBuilder.create().withId(triggerName).withTypeUID("timer.GenericCronTrigger").withConfiguration(Configuration({"cronExpression": cronExpression})).build()
 
 class StartupTrigger(Trigger):
+    """
+    This class builds a StartupTrigger Module to be used when creating a Rule.
+
+    See :ref:`Guides/Rules:Extensions` for examples of how to use these extensions.
+
+    Examples:
+        .. code-block::
+
+            MyRule.triggers = [StartupTrigger().trigger]
+
+    Args:
+        triggerName (str): Name of this trigger
+
+    Attributes:
+        trigger (Trigger): Trigger object to be added to a Rule.
+    """
     def __init__(self, triggerName=None):
-        triggerName = triggerName or uuid.uuid1().hex
+        triggerName = validate_uid(triggerName)
         self.trigger = TriggerBuilder.create().withId(triggerName).withTypeUID("jsr223.StartupTrigger").withConfiguration(Configuration()).build()
 
-# Item Registry Triggers
-
 class ItemRegistryTrigger(OsgiEventTrigger):
+    """
+    This class builds an ItemRegistryTrigger Module to be used when creating a Rule.
+    Requires the 100_OsgiEventTrigger.py component script.
+    The available Item registry ``event_names`` are:
+
+    .. code-block:: none
+
+        "ItemAddedEvent"
+        "ItemRemovedEvent"
+        "ItemUpdatedEvent"
+
+    See :ref:`Guides/Rules:Extensions` for examples of how to use these extensions.
+
+    Examples:
+        .. code-block::
+
+            MyRule.triggers = [ItemRegistryTrigger("ItemAddedEvent").trigger]
+
+    Args:
+        event_name (str): Name of the event to watch
+
+    Attributes:
+        trigger (Trigger): Trigger object to be added to a Rule.
+    """
     def __init__(self, event_name):
         OsgiEventTrigger.__init__(self)
         self.event_name = event_name
-        
+
     def event_filter(self, event):
         return event.get('type') == self.event_name
-    
+
     def event_transformer(self, event):
         return json.loads(event['payload'])
 
 class ItemAddedTrigger(ItemRegistryTrigger):
+    """
+    This class is the same as the ``ItemRegistryTrigger``, but simplifies it a bit for when an Item is added.
+    This trigger will fire when any Item is added.
+
+    See :ref:`Guides/Rules:Extensions` for examples of how to use these extensions.
+
+    Examples:
+        .. code-block::
+
+            MyRule.triggers = [ItemAddedTrigger().trigger]
+
+    Attributes:
+        trigger (Trigger): Trigger object to be added to a Rule.
+    """
     def __init__(self):
         ItemRegistryTrigger.__init__(self, "ItemAddedEvent")
-        
+
 class ItemRemovedTrigger(ItemRegistryTrigger):
-     def __init__(self):
+    """
+    This class is the same as the ``ItemRegistryTrigger``, but simplifies it a bit for when an Item is removed.
+    This trigger will fire when any Item is removed.
+
+    See :ref:`Guides/Rules:Extensions` for examples of how to use these extensions.
+
+    Examples:
+        .. code-block::
+
+            MyRule.triggers = [ItemRemovedTrigger().trigger]
+
+    Attributes:
+        trigger (Trigger): Trigger object to be added to a Rule.
+    """
+    def __init__(self):
         ItemRegistryTrigger.__init__(self, "ItemRemovedEvent")
 
 class ItemUpdatedTrigger(ItemRegistryTrigger):
+    """
+    This class is the same as the ``ItemRegistryTrigger``, but simplifies it a bit for when an Item is updated.
+    This trigger will fire when any Item is updated.
+
+    See :ref:`Guides/Rules:Extensions` for examples of how to use these extensions.
+
+    Examples:
+        .. code-block::
+
+            MyRule.triggers = [ItemUpdatedTrigger().trigger]
+
+    Attributes:
+        trigger (Trigger): Trigger object to be added to a Rule.
+    """
     def __init__(self):
         ItemRegistryTrigger.__init__(self, "ItemUpdatedEvent")
-        
-# Directory watcher trigger
 
 class DirectoryEventTrigger(Trigger):
     def __init__(self, path, event_kinds=[ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY], watch_subdirectories=False):
-        trigger_name = "{}-{}".format(type(self).__name__, uuid.uuid1().hex)
+        triggerName = validate_uid(type(self).__name__)
         config = {
             'path': path,
             'event_kinds': str(event_kinds),
             'watch_subdirectories': watch_subdirectories,
         }
-        self.trigger = TriggerBuilder.create().withId(trigger_name).withTypeUID(core.DIRECTORY_TRIGGER_MODULE_ID).withConfiguration(Configuration(config)).build()
+        self.trigger = TriggerBuilder.create().withId(triggerName).withTypeUID(core.DIRECTORY_TRIGGER_MODULE_ID).withConfiguration(Configuration(config)).build()
 
-# Function decorator trigger support
+def when(target, target_type=None, trigger_type=None, old_state=None, new_state=None):
+    """
+    This function decorator provides the ability to create rule triggers using language similar to the rules DSL.
 
-def when(target, target_type=None, trigger_type=None, old_state=None, new_state=None, event_types=None, trigger_name=None):
-    """openHAB DSL style trigger decorator.
-
-    See :ref:`Guides/Rules:Extensions` for examples of how to use these
-    extensions
+    See :ref:`Guides/Rules:Decorators` for examples of how to use this decorator
 
     Examples:
         .. code-block::
 
             @when("Item Test_Switch_1 received command OFF")
             @when("Item Test_Switch_2 received update ON")
-            @when("Item gMotion_Sensors changed to ON")
+            @when("Item Test_String_1 changed from 'old test string' to 'new test string'")
+            @when("Item gMotion_Sensors changed")
             @when("Member of gMotion_Sensors changed to OFF")
-            @when("Descendent of gContact_Sensors changed to OPEN") # Similar to 'Member of', but creates a trigger for each non-group sibling Item (think group_item.allMembers())
-            @when("Thing kodi:kodi:familyroom changed") # ThingStatusInfo (from <status> to <status>) cannot currently be used in triggers
+            @when("Descendent of gContact_Sensors changed to ON")
+            @when("Thing kodi:kodi:familyroom changed") #Thing statuses cannot currently be used in triggers
             @when("Channel astro:sun:local:eclipse#event triggered START")
-            @when("System started") # 'System started' requires S1566 or newer, and 'System shuts down' is not available
+            @when("System started") #'System started' requires S1566 or newer, and 'System shuts down' is not available
             @when("Time cron 55 55 5 * * ?")
 
     Args:
@@ -344,15 +527,13 @@ def when(target, target_type=None, trigger_type=None, old_state=None, new_state=
         trigger_type (str): Trigger type ("changed", "received command", etc.)
         old_state (str): Old state for "Item changed from" events
         new_state (str): New state for "changed to", "Item received update/command", and "Channel triggered" events
-        event_types (str): Event type for GenericEventTrigger (keeps backwards compatibility with earlier versions)
-        trigger_name (str): Name to assign to this trigger
     """
 
     try:
         def item_trigger(function):
             if not hasattr(function, 'triggers'):
                 function.triggers = []
-            item = scope.itemRegistry.getItem(trigger_target)
+            item = itemRegistry.getItem(trigger_target)
             group_members = []
             if target_type == "Member of":
                 group_members = item.getMembers()
@@ -368,7 +549,6 @@ def when(target, target_type=None, trigger_type=None, old_state=None, new_state=
                     "-to-" if new_state is not None and trigger_type == "changed" else "",
                     "-" if trigger_type == "received update" and new_state is not None else "",
                     new_state if new_state is not None else "")
-                trigger_name = validate_uid(trigger_name)
                 if trigger_type == "received update":
                     function.triggers.append(ItemStateUpdateTrigger(member.name, state=new_state, triggerName=trigger_name).trigger)
                 elif trigger_type == "received command":
@@ -376,6 +556,18 @@ def when(target, target_type=None, trigger_type=None, old_state=None, new_state=
                 else:
                     function.triggers.append(ItemStateChangeTrigger(member.name, previousState=old_state, state=new_state, triggerName=trigger_name).trigger)
                 log.debug("when: Created item_trigger: [{}]".format(trigger_name))
+            return function
+
+        def item_registry_trigger(function):
+            if not hasattr(function, 'triggers'):
+                function.triggers = []
+            event_names = {
+                'added': 'ItemAddedEvent',
+                'removed': 'ItemRemovedEvent',
+                'modified': 'ItemUpdatedEvent'
+            }
+            function.triggers.append(ItemRegistryTrigger(event_names.get(trigger_target)))
+            log.debug("when: Created item_registry_trigger: [{}]".format(event_names.get(trigger_target)))
             return function
 
         def cron_trigger(function):
@@ -395,6 +587,23 @@ def when(target, target_type=None, trigger_type=None, old_state=None, new_state=
             log.debug("when: Created system_trigger: [{}]".format(trigger_name))
             return function
 
+        def thing_trigger(function):
+            if not hasattr(function, 'triggers'):
+                function.triggers = []
+            trigger_name = "Thing-{}-{}{}{}{}{}".format(
+                trigger_target,
+                trigger_type.replace(" ","-"),
+                "-from-{}".format(old_state) if old_state is not None else "",
+                "-to-" if new_state is not None and trigger_type == "changed" else "",
+                "-" if trigger_type == "received update" and new_state is not None else "",
+                new_state if new_state is not None else "")
+            if trigger_type == "changed":
+                function.triggers.append(ThingStatusChangeTrigger(trigger_target, previousStatus=old_state, status=new_state, triggerName=trigger_name).trigger)
+            else:
+                function.triggers.append(ThingStatusUpdateTrigger(trigger_target, status=new_state, triggerName=trigger_name).trigger)
+            log.debug("when: Created thing_trigger: [{}]".format(trigger_name))
+            return function
+
         def channel_trigger(function):
             if not hasattr(function, 'triggers'):
                 function.triggers = []
@@ -402,15 +611,8 @@ def when(target, target_type=None, trigger_type=None, old_state=None, new_state=
             log.debug("when: Created channel_trigger: [{}]".format(trigger_name))
             return function
 
-        def thing_trigger(function):
-            if not hasattr(function, 'triggers'):
-                function.triggers = []
-            event_types = "ThingStatusInfoChangedEvent" if trigger_type == "changed" else "ThingStatusInfoEvent"
-            function.triggers.append(ThingEventTrigger(trigger_target, event_types, triggerName=trigger_name).trigger)
-            log.debug("when: Created thing_trigger: [{}]".format(trigger_name))
-            return function
-        
         trigger_target = None
+        trigger_name = None
         if isValidExpression(target):
             # a simple cron target was used, so add a default target_type and trigger_target (Time cron XXXXX)
             target_type = "Time"
@@ -484,7 +686,7 @@ def when(target, target_type=None, trigger_type=None, old_state=None, new_state=
                             raise ValueError("when: \"{}\" could not be parsed. \"{}\" is invalid for \"{} {} {}\"".format(target, inputList, target_type, trigger_target, trigger_type))
 
             else:
-                # a simple Item target was used, so add a default target_type and trigger_type (Item XXXXX changed)
+                # a simple Item target was used (just an Item name), so add a default target_type and trigger_type (Item XXXXX changed)
                 if target_type is None:
                     target_type = "Item"
                 if trigger_target is None:
@@ -492,42 +694,43 @@ def when(target, target_type=None, trigger_type=None, old_state=None, new_state=
                 if trigger_type is None:
                     trigger_type = "changed"
 
-            trigger_name = validate_uid(trigger_name or target)
+            trigger_name = trigger_name or target
 
         # validate the inputs, and if anything isn't populated correctly throw an exception
         if target_type is None or target_type not in ["Item", "Member of", "Descendent of", "Thing", "Channel", "System", "Time"]:
             raise ValueError("when: \"{}\" could not be parsed. target_type is missing or invalid. Valid target_type values are: Item, Member of, Descendent of, Thing, Channel, System, and Time.".format(target))
-        elif target_type != "System" and trigger_type is None:
-            raise ValueError("when: \"{}\" could not be parsed because trigger_type cannot be None".format(target)) 
-        elif target_type in ["Item", "Member of", "Descendent of"] and scope.itemRegistry.getItems(trigger_target) == []:
+        elif target_type != "System" and trigger_target not in ["added", "removed", "modified"] and trigger_type is None:
+            raise ValueError("when: \"{}\" could not be parsed because trigger_type cannot be None".format(target))
+        elif target_type in ["Item", "Member of", "Descendent of"] and trigger_target not in ["added", "removed", "modified"] and itemRegistry.getItems(trigger_target) == []:
             raise ValueError("when: \"{}\" could not be parsed because Item \"{}\" is not in the ItemRegistry".format(target, trigger_target))
-        elif target_type in ["Member of", "Descendent of"] and scope.itemRegistry.getItem(trigger_target).type != "Group":
+        elif target_type in ["Member of", "Descendent of"] and itemRegistry.getItem(trigger_target).type != "Group":
             raise ValueError("when: \"{}\" could not be parsed because \"{}\" was specified, but \"{}\" is not a group".format(target, target_type, trigger_target))
-        elif target_type == "Item" and old_state is not None and trigger_type == "changed" and TypeParser.parseState(scope.itemRegistry.getItem(trigger_target).acceptedDataTypes, old_state) is None:
+        elif target_type == "Item" and trigger_target not in ["added", "removed", "modified"] and old_state is not None and trigger_type == "changed" and TypeParser.parseState(itemRegistry.getItem(trigger_target).acceptedDataTypes, old_state) is None:
             raise ValueError("when: \"{}\" could not be parsed because \"{}\" is not a valid state for \"{}\"".format(target, old_state, trigger_target))
-        elif target_type == "Item" and new_state is not None and (trigger_type == "changed" or trigger_type == "received update") and TypeParser.parseState(scope.itemRegistry.getItem(trigger_target).acceptedDataTypes, new_state) is None:
+        elif target_type == "Item" and trigger_target not in ["added", "removed", "modified"] and new_state is not None and (trigger_type == "changed" or trigger_type == "received update") and TypeParser.parseState(itemRegistry.getItem(trigger_target).acceptedDataTypes, new_state) is None:
             raise ValueError("when: \"{}\" could not be parsed because \"{}\" is not a valid state for \"{}\"".format(target, new_state, trigger_target))
-        elif target_type == "Item" and new_state is not None and trigger_type == "received command" and TypeParser.parseCommand(scope.itemRegistry.getItem(trigger_target).acceptedCommandTypes, new_state) is None:
+        elif target_type == "Item" and trigger_target not in ["added", "removed", "modified"] and new_state is not None and trigger_type == "received command" and TypeParser.parseCommand(itemRegistry.getItem(trigger_target).acceptedCommandTypes, new_state) is None:
             raise ValueError("when: \"{}\" could not be parsed because \"{}\" is not a valid command for \"{}\"".format(target, new_state, trigger_target))
-        elif target_type == "Channel" and scope.things.getChannel(ChannelUID(trigger_target)) is None:# returns null if Channel does not exist
-            raise ValueError("when: \"{}\" could not be parsed because Channel \"{}\" does not exist".format(target, trigger_target))
-        elif target_type == "Channel" and scope.things.getChannel(ChannelUID(trigger_target)).kind != ChannelKind.TRIGGER:
-            raise ValueError("when: \"{}\" could not be parsed because Channel \"{}\" is not a trigger".format(target, trigger_target))
-        elif target_type == "Thing" and scope.things.get(ThingUID(trigger_target)) is None:# returns null if Thing does not exist
+        elif target_type == "Thing" and things.get(ThingUID(trigger_target)) is None:# returns null if Thing does not exist
             raise ValueError("when: \"{}\" could not be parsed because Thing \"{}\" is not in the ThingRegistry".format(target, trigger_target))
-        elif target_type == "Thing" and old_state and not hasattr(ThingStatus, old_state):
+        elif target_type == "Thing" and old_state is not None and not hasattr(ThingStatus, old_state):
             raise ValueError("when: \"{}\" is not a valid Thing status".format(old_state))
-        elif target_type == "Thing" and new_state and not hasattr(ThingStatus, new_state):
-            raise ValueError("when: \"{}\" is not a valid Thing status".format(new_state))   
-        elif target_type == "Thing" and (old_state is not None or new_state is not None):# there is only an event trigger for Things, so old_state and new_state can't be used yet *****TO BE REMOVED*****
-            raise ValueError("when: \"{}\" could not be parsed because rule triggers do not currently support checking the from/to status for Things".format(target))
+        elif target_type == "Thing" and new_state is not None and not hasattr(ThingStatus, new_state):
+            raise ValueError("when: \"{}\" is not a valid Thing status".format(new_state))
+        elif target_type == "Channel" and things.getChannel(ChannelUID(trigger_target)) is None:# returns null if Channel does not exist
+            raise ValueError("when: \"{}\" could not be parsed because Channel \"{}\" does not exist".format(target, trigger_target))
+        elif target_type == "Channel" and things.getChannel(ChannelUID(trigger_target)).kind != ChannelKind.TRIGGER:
+            raise ValueError("when: \"{}\" could not be parsed because Channel \"{}\" is not a trigger".format(target, trigger_target))
         elif target_type == "System" and trigger_target != "started":# and trigger_target != "shuts down":
             raise ValueError("when: \"{}\" could not be parsed. trigger_target \"{}\" is invalid for target_type \"System\". The only valid trigger_type value is \"started\"".format(target, target_type))# and \"shuts down\"".format(target, target_type))
 
         log.debug("when: target=[{}], target_type={}, trigger_target={}, trigger_type={}, old_state={}, new_state={}".format(target, target_type, trigger_target, trigger_type, old_state, new_state))
 
         if target_type in ["Item", "Member of", "Descendent of"]:
-            return item_trigger
+            if trigger_target in ["added", "removed", "modified"]:
+                return item_registry_trigger
+            else:
+                return item_trigger
         elif target_type == "Thing":
             return thing_trigger
         elif target_type == "Channel":
@@ -544,14 +747,10 @@ def when(target, target_type=None, trigger_type=None, old_state=None, new_state=
             if not hasattr(function, 'triggers'):
                 function.triggers = []
             function.triggers.append(None)
-            #log.warn("triggers = [{}]".format(function.triggers))
-            #log.warn("all None = [{}]".format(all(function.triggers)))
-            #log.warn("count = [{}]".format(function.triggers.count(None)))
-            #function.has_bad_trigger = True
             return function
 
         return bad_trigger
 
-    except:       
+    except:
         import traceback
         log.debug(traceback.format_exc())

--- a/Sphinx/Guides/Triggers.rst
+++ b/Sphinx/Guides/Triggers.rst
@@ -31,7 +31,6 @@ Items and Groups
                 @when("Member of GROUP_NAME received update [NEW_STATE]")
                 @when("Descendent of GROUP_NAME received update [NEW_STATE]")
 
-                @when("ITEM_NAME") # shorthand of "Item ITEM_NAME changed"
                 @when("Item ITEM_NAME changed [from OLD_STATE] [to NEW_STATE]")
                 @when("Item GROUP_NAME changed [from OLD_STATE] [to NEW_STATE]")
                 @when("Member of GROUP_NAME changed [from OLD_STATE] [to NEW_STATE]")
@@ -77,56 +76,12 @@ Items and Groups
         If the state or command used in the ``when`` decorator has special characters, including spaces, it must be surrounded in single quotes ``'like this'`` to prevent errors.
 
 
-Channel Event
-=============
-
-    Channel triggers allow you to catch events from bindings using channels.
-    You should find channel names and events in the documentation for the binding.
-
-    .. tabs::
-
-        .. group-tab:: Python
-
-            .. code-block::
-
-                @when("Channel CHANNEL:NAME")
-                @when("Channel CHANNEL:NAME triggered")
-                @when("Channel CHANNEL:NAME triggered EVENT")
-
-        .. group-tab:: JavaScript
-
-            Decorators have not yet been created for the JavaScript helper libraries.
-
-        .. group-tab:: Groovy
-
-            Decorators have not yet been created for the Groovy helper libraries.
-
-        .. group-tab:: Rules DSL
-
-            .. code-block:: java
-
-                Channel "CHANNEL:NAME"
-                Channel "CHANNEL:NAME" triggered
-                Channel "CHANNEL:NAME" triggered EVENT
-
-    If you need the name of the channel or event that triggered the rule, they are available as ``event.channel`` and ``event.event`` respectively.
-
-    .. warning::
-
-        If the event used in the ``when`` decorator has special characters, including spaces, it must be surrounded in single quotes ``'like this'`` to prevent errors.
-
-
 Thing Event
 ===========
 
     Thing status changes can also be used to trigger rules.
     A list of all available statuses can be found `here <https://www.openhab.org/docs/concepts/things.html>`_.
-
-    .. note::
-
-        | Thing triggers do not yet support ``NEW_STATE`` or ``OLD_STATE`` conditions.
-          This is a limitation of the openHAB Automation API.
-        | If you need to trigger on a specific event, you can get the event name via ``event.statusInfo`` and check if it is the event you needed.
+    If you need to trigger on a specific status, you can get the status name via ``event.statusInfo.status`` and check if it is the status that you needed.
 
     .. tabs::
 
@@ -134,8 +89,8 @@ Thing Event
 
             .. code-block::
 
-                @when("Thing THING:NAME received update")
-                @when("Thing THING:NAME changed")
+                @when("Thing THING:NAME received update [NEW_STATE]")
+                @when("Thing THING:NAME changed [from OLD_STATE] [to NEW_STATE]")
 
         .. group-tab:: JavaScript
 
@@ -149,12 +104,53 @@ Thing Event
 
             .. code-block:: java
 
-                Thing "THING:NAME" received update
-                Thing "THING:NAME" received update NEW_STATE
-                Thing "THING:NAME" changed
-                Thing "THING:NAME" changed to NEW_STATE
-                Thing "THING:NAME" changed from OLD_STATE to NEW_STATE
-                Thing "THING:NAME" changed from NEW_STATE
+                Thing "THING:NAME" received update [NEW_STATE]
+                Thing "THING:NAME" changed [from OLD_STATE] [to NEW_STATE]
+
+    .. warning::
+
+        If the status used in the ``when`` decorator has special characters, including spaces, it must be surrounded in single quotes ``'like this'`` to prevent errors.
+
+
+Channel Event
+=============
+
+    Channel triggers allow you to catch events from bindings using Channels.
+    You can find Channel names and events in the documentation for the binding.
+
+    .. note::
+
+        Only *trigger* Channels can be used with this trigger, `same as in the rules DSL <https://www.openhab.org/docs/configuration/rules-dsl.html#channel-based-triggers>`_.
+        If not using a trigger Channel, you will receive a validation error when saving the script.
+        The binding documentation will identify which Channels, if any, are trigger Channels.
+
+    .. tabs::
+
+        .. group-tab:: Python
+
+            .. code-block::
+
+                @when("Channel CHANNEL:NAME triggered [EVENT]")
+
+        .. group-tab:: JavaScript
+
+            Decorators have not yet been created for the JavaScript helper libraries.
+
+        .. group-tab:: Groovy
+
+            Decorators have not yet been created for the Groovy helper libraries.
+
+        .. group-tab:: Rules DSL
+
+            .. code-block:: java
+
+                Channel "CHANNEL:NAME" triggered [EVENT]
+
+    If you need the name of the Channel or event that triggered the rule, they are available as ``event.channel`` and ``event.event``, respectively.
+
+    .. warning::
+
+        If the event used in the ``when`` decorator has special characters, including spaces, it must be surrounded in single quotes ``'like this'`` to prevent errors.
 
 
 Cron
@@ -175,12 +171,7 @@ Cron
 
             .. code-block::
 
-                @when("5 5 5 * * ?")
                 @when("Time cron 55 55 5 * * ?")
-                @when(triggers.EVERY_SECOND)
-                @when(triggers.EVERY_10_SECONDS)
-                @when(triggers.EVERY_MINUTE)
-                @when(triggers.EVERY_HOUR)
 
         .. group-tab:: JavaScript
 
@@ -194,7 +185,7 @@ Cron
 
             .. code-block:: java
 
-                Time cron "5 5 5 * * ?"
+                Time cron "55 55 5 * * ?"
 
 
 System Started
@@ -243,7 +234,6 @@ System Started
                 def my_rule_function(event):
                     # your Python code here
 
-
                 def scriptLoaded(id):
                     # call rule function when this file is loaded
                     my_rule_function(None)
@@ -260,37 +250,9 @@ System Started
 System Shuts Down
 =================
 
-    The system shuts down trigger can be used to run a rule when openHAB shuts down.
-
-    .. warning::
-
-        | There is currently no working ``"System shuts down"`` trigger.
-          Any rules using this trigger with the ``when`` decorator will not trigger when openHAB is exiting.
-        | See below for a workaround.
-
-    .. tabs::
-
-        .. group-tab:: Python
-
-            .. code-block::
-
-                @when("System shuts down")
-
-        .. group-tab:: JavaScript
-
-            Decorators have not yet been created for the JavaScript helper libraries.
-
-        .. group-tab:: Groovy
-
-            Decorators have not yet been created for the Groovy helper libraries.
-
-        .. group-tab:: Rules DSL
-
-            .. code-block:: java
-
-                System shuts down
-
-    There is a workaround to run a rule when the script file gets unloaded, similar to the StartupTrigger workaround:
+    There is currently no working ``"System shuts down"`` trigger.
+    If attempting to use this trigger with the ``when`` decorator, you will receive a validation error when saving the script.
+    Below are workarounds for executing a function when a script is unloaded, similar to what is described for ``System started``.
 
     .. tabs::
 
@@ -303,9 +265,8 @@ System Shuts Down
                 def my_rule_function(event):
                     # your Python code here
 
-
                 def scriptUnloaded():
-                    # call rule when this file is unloaded
+                    # call rule function when this file is unloaded, but be sure an event of None is handled
                     my_rule_function(None)
 
         .. group-tab:: JavaScript
@@ -315,3 +276,9 @@ System Shuts Down
         .. group-tab:: Groovy
 
             TODO
+
+        .. group-tab:: Rules DSL
+
+            .. code-block:: java
+
+                System shuts down

--- a/Sphinx/Python/Core/Packages and Modules/utils.rst
+++ b/Sphinx/Python/Core/Packages and Modules/utils.rst
@@ -1,0 +1,5 @@
+utils
+-----
+
+.. automodule:: core.utils
+    :members:


### PR DESCRIPTION
1. added ThingStatusUpdateTrigger and ThingStatusChangeTrigger to core.triggers and core.triggers.when decorator (https://github.com/openhab/openhab-core/pull/911)
2. removed event_type and trigger_name parameters from core.triggers.when
3. Removed reference to the simple when decorator formats. They should work now, but let's not promote them so that they can be removed in the future.
4. DirectoryEventTrigger, ItemAddedTrigger, ItemRemovedTrigger and ItemUpdatedTrigger have not worked for a long time and I'm close, but more work needs to be done to OSGIEventTrigger for them to work properly. This PR adds them to the core.triggers.when decorator.
5. Made some fixes to core.utils.validate_uid and changed core.triggers to use it in all of the trigger classes for generating the trigger name. Previously, it was possible that the trigger names were not unique, but that should no longer be possible.

Fixes #180, #187, #189 

Signed-off-by: Scott Rushworth <openhab@5iver.com>