### PR TITLE
Use simplified installation instructions for Python

### DIFF
--- a/Sphinx/Getting Started/Docker.rst
+++ b/Sphinx/Getting Started/Docker.rst
@@ -17,7 +17,7 @@ Docker
                 
             .. code-block:: bash
 
-                wget https://github.com/OH-Jython-Scripters/openhab2-jython/archive/master.zip
+                wget https://github.com/openhab-scripters/openhab-helper-libraries/archive/master.zip
                 unzip master.zip
                 mv openhab2-jython-master/automation conf/
 
@@ -31,31 +31,18 @@ Docker
             .. code-block:: bash
 
                 curl http://search.maven.org/remotecontent?filepath=org/python/jython-standalone/2.7.0/jython-standalone-2.7.0.jar -o jython-standalone-2.7.0.jar
-                mkdir conf/automation/jython
-                mv jython-standalone-2.7.0.jar conf/automation/jython/
+                mkdir libext
+                mv jython-standalone-2.7.0.jar libext/
+                echo "python.path=/openhab/conf/automation/lib/python" > libext/registry
 
-            Again, the ``conf`` directory above is the directory that's mounted in openHAB.
+            The directory ``libext`` should be mounted into the openHAB container at ``/openhab/runtime/lib/ext``.
+            The echo command adds the Python path to the registry file that is read when Jython is loaded.
 
         #.  Finally, copy over the ``hello_world.py`` script so we can see things happening in the logs.
 
             .. code-block:: bash
 
                 cp openhab2-jython-master/Script\ Examples/Python/hello_world.py conf/automation/jsr223/python/personal
-
-        Docker Environment
-
-        #.  When starting the docker container, include the environment variable as follows:
-
-            .. code-block:: bash
-
-                -e "EXTRA_JAVA_OPTS=-Xbootclasspath/a:/openhab/conf/automation/jython/jython-standalone-2.7.0.jar -Dpython.home=/openhab/conf/automation/jython -Dpython.path=/openhab/conf/automation/lib/python"
-
-            Or, if you are using a compose file, include this:
-
-            .. code-block:: bash
-
-                environment:
-                EXTRA_JAVA_OPTS: "-Xbootclasspath/a:/openhab/conf/automation/jython/jython-standalone-2.7.0.jar -Dpython.home=/openhab/conf/automation/jython -Dpython.path=/openhab/conf/automation/lib/python"
 
         #.  Restart openHAB.
             You should see something such as this in the logs:
@@ -70,7 +57,7 @@ Docker
 
                 2018-10-17 02:24:40.077 [INFO ] [eclipse.smarthome.model.script.Rules] - JSR223: This is a 'hello world!' from a Jython rule (decorator): Cron
 
-        Building image from Dockerfile
+        Building image from Dockerfile *(outdated)*
 
         In the `/Docker/Python/` directory, there is an example Dockerfile which will add Jython support to the given container version.
         It includes a script to enable the `Next-Generation Rule Engine`_ in the addons.cfg and adds necessary entries to ``EXTRA_JAVA_OPTS`` (including setting python.path to ``/openhab/conf/automation/lib/python/``).

--- a/Sphinx/Getting Started/Installation.rst
+++ b/Sphinx/Getting Started/Installation.rst
@@ -62,6 +62,10 @@ Instructions for installation in a Docker container are available :doc:`here <Do
 .. |core_step_11| replace::
     Check out the :doc:`First Steps` page for what to do next.
 
+.. |jython_other_verions| replace::
+    A full installation of Jython can also be used, but the paths above would need to be modified.
+    Jython 2.7.1 and 2.7.2a1+ will also work, but 2.7.0 has proven to be very stable.
+
 .. tabs::
 
     .. group-tab:: Python
@@ -76,44 +80,75 @@ Instructions for installation in a Docker container are available :doc:`here <Do
         #. |core_step_8a|
            For example, in ``/automation/lib/python/``, rename the file ``configuration.py.example`` to ``configuration.py``.
            |core_step_8b|
-        #. Add/modify the EXTRA_JAVA_OPTS.
+        #. Add/modify the Python registry file.
            These examples assume that you will be using the standalone Jython 2.7.0 jar in the next step.
-           Changes to the EXTRA_JAVA_OPTS require an openHAB restart.
 
            .. tabs::
 
-               .. group-tab:: Using an ``/etc/default/openhab2`` file
+               .. group-tab:: Package Install
 
-                   This option is typically used with a package repository openHAB installation (includes openHABian).
-                   If creating a new file, remember to set the permissions so that the `openhab` account has at least read access.
-                   If a file already exists and there is an EXTRA_JAVA_OPTS variable, add a space and append everything in quotes.
+                   The paths shown here are for Linux package repository openHAB installations, including openHABian.
 
-                   .. code-block:: none
+                   Edit the file ``/usr/share/openhab2/runtime/lib/ext/registry`` using your preferred text editor,
+                   making directories as needed.
 
-                       EXTRA_JAVA_OPTS="-Xbootclasspath/a:/etc/openhab2/automation/jython/jython-standalone-2.7.0.jar -Dpython.home=/etc/openhab2/automation/jython -Dpython.path=/etc/openhab2/automation/lib/python"
+                   If creating a new file, remember to set the permissions so that the ``openhab`` account has at least read access.
+                   If a file already exists and there is a ``python.path`` variable, add a semi-colon and append the following.
 
-               .. group-tab:: Using the ``start.sh`` script
+                   .. code-block:: Text
 
-                   This option is typically used with a manual openHAB installation on Linux.
+                       python.path=/etc/openhab2/automation/lib/python
 
-                   .. code-block:: none
+               .. group-tab:: Manual Install
 
-                       # Add to the top of the file
-                       export EXTRA_JAVA_OPTS="-Xbootclasspath/a:/opt/openhab2/conf/automation/jython/jython-standalone-2.7.0.jar -Dpython.home=/opt/openhab2/conf/automation/jython -Dpython.path=/opt/openhab2/conf/automation/lib/python"
+                   The paths shown here are the defaults for manual openHAB installations on Linux.
 
-               .. group-tab:: Using the ``start.bat`` script
+                   Edit the file ``/opt/openhab2/runtime/lib/ext/registry`` using your preferred text editor,
+                   making directories as needed.
 
-                   This option is for a manual openHAB installation on Windows.
-                   If you are *not* using OH 2.5, 2.5M2, S1604, or newer, you will first need to update your ``C:\openhab2\runtime\bin\setenv.bat`` file with the `changes in the current file <https://github.com/openhab/openhab-distro/blob/master/distributions/openhab/src/main/resources/bin/setenv.bat#L121>`_.
+                   If creating a new file, remember to set the permissions so that the ``openhab`` account has at least read access.
+                   If a file already exists and there is a ``python.path`` variable, add a semi-colon and append the following.
 
-                   .. code-block:: none
+                   .. code-block:: Text
 
-                       REM Add to the top of the file
-                       set EXTRA_JAVA_OPTS=-Xbootclasspath/a:C:\openhab2\conf\automation\jython\jython-standalone-2.7.0.jar -Dpython.home=C:\openhab2\conf\automation\jython -Dpython.path=C:\openhab2\conf\automation\lib\python
+                       python.path=/opt/openhab2/conf/automation/lib/python
 
-        #. Download the `standalone Jython 2.7.0 jar <http://www.jython.org/downloads.html>`_ and copy it to the path specified above in the EXTRA_JAVA_OPTS.
-           A full installation of Jython can also be used, but the paths above would need to be modified.
-           Jython 2.7.1 and 2.7.2a1+ will also work, but 2.7.0 has proven to be very stable.
+               .. group-tab:: Windows Install
+
+                   The paths shown here are examples for Windows openHAB installations.
+
+                   Edit the file ``C:\openhab2\runtime\lib\ext\registry`` using your preferred text editor,
+                   making directories as needed.
+
+                   If a file already exists and there is a ``python.path`` variable, add a semi-colon and append the following.
+
+                   .. code-block:: Text
+
+                       python.path=C:\openhab2\conf\automation\lib\python
+
+        #. .. tabs::
+
+               .. group-tab:: Package Install
+
+                   Download the `standalone Jython 2.7.0 jar <http://www.jython.org/downloads.html>`_ and copy it to
+                   ``/usr/share/openhab2/runtime/lib/ext/``
+
+                   |jython_other_verions|
+
+               .. group-tab:: Manual Install
+
+                   Download the `standalone Jython 2.7.0 jar <http://www.jython.org/downloads.html>`_ and copy it to
+                   ``/opt/openhab2/runtime/lib/ext/``
+
+                   |jython_other_verions|
+
+               .. group-tab:: Windows Install
+
+                   Download the `standalone Jython 2.7.0 jar <http://www.jython.org/downloads.html>`_ and copy it to
+                   ``C:\openhab2\runtime\lib\ext\``
+
+                   |jython_other_verions|
+
         #. Copy the ``/Script Examples/Python/hello_world.py`` script to ``/automation/jsr223/python/personal/``.
         #. |core_step_9|
         #. |core_step_10|


### PR DESCRIPTION
This PR updates the documentation to use the `lib/ext/` dir and `registry` file to make installing Python/Jython less complicated.

Signed-off-by: Michael Murton <6764025+CrazyIvan359@users.noreply.github.com>