### PR TITLE
Add VSCode setup hints

### DIFF
--- a/Sphinx/Getting Started/VS Code.rst
+++ b/Sphinx/Getting Started/VS Code.rst
@@ -1,0 +1,61 @@
+*****************
+Setting up VSCode
+*****************
+
+The following steps will configure Visual Studio Code to recognize the Helper Libraries
+and provide examples of how to reduce the number of errors being displayed because VSCode
+does not have access to any openHAB packages.
+
+ENV File
+========
+
+    Create a ``.env`` file in the root of your openHAB conf directory (ex ``{OH_CONF}/.env``)
+    and add the following to it:
+
+    .. code-block:: Text
+
+        PYTHONPATH="./automation/lib/python"
+
+    This will allow ``pylint`` to see any packages or modules in that directory and no longer
+    show import errors for them.
+
+Exclude Helper Libraries
+========================
+
+    If you don't already have an ``{OH_CONF}/.vscode/settings.json`` file, create it and
+    add the following:
+
+    .. code-block:: JSON
+
+        {
+            "python.linting.ignorePatterns": [
+                "**/automation/**/python/core/**/*.py",
+                "**/automation/**/python/community/**/*.py"
+            ]
+        }
+
+    This will tell ``pylint`` to ignore all files in the Helper Libraries' ``core`` and
+    ``community`` directories, greatly reducing the number of errors you will see
+    because of openHAB packages it cannot import.
+
+pylint Directives
+=================
+
+    Lastly, you can use ``pylint`` directives if you want to disable the import error
+    messages in your files for the openHAB packages that it cannot import.
+
+    When importing packages or classes from openHAB:
+
+    .. code-block::
+
+        # pylint: disable=import-error
+        from org.openhab.core.library.items import SwitchItem
+        # pylint: enable=import-error
+
+    When importing ``scope`` from ``core.jsr223``:
+
+    .. code-block::
+
+        # pylint: disable=import-error, no-name-in-module
+        from core.jsr223 import scope
+        # pylint: enable=import-error, no-name-in-module

--- a/Sphinx/index.rst
+++ b/Sphinx/index.rst
@@ -22,6 +22,7 @@ The one exception is that custom module handlers, including the StartupTrigger, 
     Getting Started/Installation.rst
     Getting Started/File Locations.rst
     Getting Started/First Steps.rst
+    Getting Started/VS Code
 
 
 .. toctree::


### PR DESCRIPTION
This PR adds a page in the docs detailing ways to improve linting Python rules and modules in VSCode as detailed in [this post](https://community.openhab.org/t/python-how-to-correctly-setup-vscode-to-use-openhab-helper-libraries/76966/4?u=crazyivan359).

Signed-off-by: Michael Murton <6764025+CrazyIvan359@users.noreply.github.com>