### PR TITLE
[date] Add human readable seconds

### DIFF
--- a/Core/automation/lib/python/core/date.py
+++ b/Core/automation/lib/python/core/date.py
@@ -1,24 +1,15 @@
 """
-The Date module provides data types and methods for working with DateTime items.
+This module provides functions for date and time conversions.
 
 Types
 =====
 
     It is recommended that you use ``java.time.ZonedDateTime`` for all
-    operations involving dates or ``DateTime`` items. See the documentation for
+    operations involving dates or ``DateTime`` Items. See the documentation for
     `java.time.ZonedDateTime <https://docs.oracle.com/javase/8/docs/api/java/time/ZonedDateTime.html>`_
     for more information about its useage.
 
-    .. warning::
-
-        The use of ``org.joda.DateTime`` for new rules is not recommended as the
-        Joda package may not be available in future versions of openHAB. You
-        will find that ``java.time.ZonedDateTime`` has many functions in common
-        with ``org.joda.DateTime``, which should make transitioning fairly
-        straight forward.
-
-    All of the methods in this module can accept any of the following DateTime
-    types:
+    The functions in this module can accept any of the following date types:
 
     .. code-block::
 
@@ -56,7 +47,7 @@ from java.util import Calendar, Date, TimeZone
 from org.eclipse.smarthome.core.library.types import DateTimeType as eclipseDateTime
 
 try:
-    # if the compat1.x bundle is not installed the 1.x DateTimeType is not available
+    # if the compat1x bundle is not installed, the OH 1.x DateTimeType is not available
     from org.openhab.core.library.types import DateTimeType as legacyDateTime
 except:
     legacyDateTime = None
@@ -74,8 +65,8 @@ def format_date(value, format_string="yyyy-MM-dd'T'HH:mm:ss.SSxx"):
     Returns string of ``value`` formatted according to ``format_string``.
 
     This function can be used when updating Items in openHAB or to format any
-    DateTime value for output. The default format string follows the same
-    ISO8601 format used in openHAB.
+    date value for output. The default format string follows the same ISO8601
+    format used in openHAB.
 
     Examples:
         .. code-block::
@@ -83,16 +74,16 @@ def format_date(value, format_string="yyyy-MM-dd'T'HH:mm:ss.SSxx"):
             sendCommand("date_item", format_date(date_value))
             log.info("The time is currently: {}".format(format_date(ZonedDateTime.now())))
 
-    Args:
-        value: Any known DateTime value.
+    Arguments:
+        value: Any supported date value
         format_string (str): Pattern to format ``value`` with.
             See `java.time.format.DateTimeFormatter <https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html>`_
             for format string tokens.
 
     Returns:
-        | A string representation of ``value`` according to ``format_string``.
-        | If ``value`` does not have timezone information, the system default
-          will be used.
+        A string representation of ``value`` according to ``format_string``.
+        If ``value`` does not have timezone information, the system default
+        will be used.
     """
     return to_java_zoneddatetime(value).format(DateTimeFormatter.ofPattern(format_string))
 
@@ -106,11 +97,11 @@ def days_between(value_from, value_to, calendar_days=False):
 
             span_days = days_between(items["date_item"], ZonedDateTime.now())
 
-    Args:
-        value_from: Value to start from.
-        value_to: Value to measure to.
-        calendar_days (bool): If ``True`` will return calendar days between
-            instead of 24-hour periods between.
+    Arguments:
+        value_from: Value to start from
+        value_to: Value to measure to
+        calendar_days (bool): If ``True``, the value returned will be the
+            number of calendar days rather than 24-hour periods (default).
     """
     if calendar_days:
         return DAYS.between(to_java_zoneddatetime(value_from).toLocalDate().atStartOfDay(), to_java_zoneddatetime(value_to).toLocalDate().atStartOfDay())
@@ -127,9 +118,9 @@ def hours_between(value_from, value_to):
 
             span_hours = hours_between(items["date_item"], ZonedDateTime.now())
 
-    Args:
-        value_from: Value to start from.
-        value_to: Value to measure to.
+    Arguments:
+        value_from: Value to start from
+        value_to: Value to measure to
     """
     return HOURS.between(to_java_zoneddatetime(value_from), to_java_zoneddatetime(value_to))
 
@@ -143,9 +134,9 @@ def minutes_between(value_from, value_to):
 
             span_minutes = minutes_between(items["date_item"], ZonedDateTime.now())
 
-    Args:
-        value_from: Value to start from.
-        value_to: Value to measure to.
+    Arguments:
+        value_from: Value to start from
+        value_to: Value to measure to
     """
     return MINUTES.between(to_java_zoneddatetime(value_from), to_java_zoneddatetime(value_to))
 
@@ -159,31 +150,30 @@ def seconds_between(value_from, value_to):
 
             span_seconds = seconds_between(items["date_item"], ZonedDateTime.now())
 
-    Args:
-        value_from: Value to start from.
-        value_to: Value to measure to.
+    Arguments:
+        value_from: Value to start from
+        value_to: Value to measure to
     """
     return SECONDS.between(to_java_zoneddatetime(value_from), to_java_zoneddatetime(value_to))
 
 def to_java_zoneddatetime(value):
     """
-    Converts any known DateTime type to a ``java.time.ZonedDateTime`` type.
+    Converts any of the supported date types to ``java.time.ZonedDateTime``.
 
     Examples:
         .. code-block::
 
             java_time = to_java_zoneddatetime(items["date_item"])
 
-    Args:
-        value: Any known DateTime value.
+    Arguments:
+        value: Any supported date value
 
     Returns:
-        | A ``java.time.ZonedDateTime`` representing ``value``.
-        | If ``value`` does not have timezone information, the system default
-          will be used.
+        A ``java.time.ZonedDateTime`` representing ``value``. If ``value``
+        does not have timezone information, the system default will be used.
 
     Raises:
-        TypeError: If type of ``value`` is not recognized by this package.
+        TypeError: If the type of ``value`` is not supported by this module
     """
     if isinstance(value, ZonedDateTime):
         return value
@@ -225,23 +215,22 @@ def to_java_zoneddatetime(value):
 
 def to_python_datetime(value):
     """
-    Converts any known DateTime type to a Python ``datetime.datetime`` type.
+    Converts any of the supported date types to Python ``datetime.datetime``.
 
     Examples:
         .. code-block::
 
             python_time = to_python_datetime(items["date_item"])
 
-    Args:
-        value: Any known DateTime value.
+    Arguments:
+        value: Any supported date value
 
     Returns:
-        | A Python ``datetime.datetime`` representing ``value``.
-        | If ``value`` does not have timezone information, the system default
-          will be used.
+        A Python ``datetime.datetime`` representing ``value``. If ``value``
+        does not have timezone information, the system default will be used.
 
     Raises:
-        TypeError: If type of ``value`` is not recognized by this package.
+        TypeError: If the type of ``value`` is not supported by this module
     """
     if isinstance(value, datetime.datetime):
         return value
@@ -263,8 +252,8 @@ class _pythonTimezone(datetime.tzinfo):
     def __init__(self, offset=0, name=""):
         """
         Python tzinfo with ``offset`` in minutes and name ``name``.
-    
-        Args:
+
+        Arguments:
             offset (int): Timezone offset from UTC in minutes.
             name (str): Display name of this instance.
         """
@@ -282,15 +271,15 @@ class _pythonTimezone(datetime.tzinfo):
 
 def to_joda_datetime(value):
     """
-    Converts any known DateTime type to a ``org.joda.time.DateTime`` type.
+    Converts any of the supported date types to ``org.joda.time.DateTime``.
 
     Examples:
         .. code-block::
 
             joda_time = to_joda_datetime(items["date_item"])
 
-    Args:
-        value: Any known DateTime value.
+    Arguments:
+        value: Any supported date value
 
     Returns:
         | An ``org.joda.time.DateTime`` representing ``value``.
@@ -298,7 +287,7 @@ def to_joda_datetime(value):
           will be used.
 
     Raises:
-        TypeError: If type of ``value`` is not recognized by this package.
+        TypeError: If type of ``value`` is not suported by this package.
     """
     if isinstance(value, DateTime):
         return value
@@ -311,23 +300,22 @@ def to_joda_datetime(value):
 
 def to_java_calendar(value):
     """
-    Converts any known DateTime type to a ``java.util.Calendar`` type.
+    Converts any of the supported date types to ``java.util.Calendar``.
 
     Examples:
         .. code-block::
 
             calendar_time = to_java_calendar(items["date_item"])
 
-    Args:
-        value: Any known DateTime value.
+    Arguments:
+        value: Any supported date value
 
     Returns:
-        | A ``java.util.Calendar`` representing ``value``.
-        | If ``value`` does not have timezone information, the system default
-          will be used.
+        A ``java.util.Calendar`` representing ``value``. If ``value`` does not
+        have timezone information, the system default will be used.
 
     Raises:
-        TypeError: If type of ``value`` is not recognized by this package.
+        TypeError: If type of ``value`` is not supported by this package.
     """
     if isinstance(value, Calendar):
         return value
@@ -342,3 +330,43 @@ def to_java_calendar(value):
     new_calendar.set(Calendar.SECOND, value_zoneddatetime.getSecond())
     new_calendar.set(Calendar.MILLISECOND, int(value_zoneddatetime.getNano() / 1000000))
     return new_calendar
+
+def human_readable_seconds(seconds):
+    """
+    Converts seconds into a human readable string of days, hours, minutes and seconds.
+
+    Examples:
+        .. code-block::
+
+            message = human_readable_seconds(55555)
+            # 15 hours, 25 minutes and 55 seconds
+
+    Arguments:
+        seconds: The number of seconds
+
+    Returns:
+        string: A string in the format ``{} days, {} hours, {} minutes and {} seconds``
+    """
+    number_of_days = seconds//86400
+    number_of_hours = (seconds%86400)//3600
+    number_of_minutes = (seconds%3600)//60
+    number_of_seconds = (seconds%3600)%60
+
+    days_string = "{} day{}".format(number_of_days, "s" if number_of_days > 1 else "")
+    hours_string = "{} hour{}".format(number_of_hours, "s" if number_of_hours > 1 else "")
+    minutes_string = "{} minute{}".format(number_of_minutes, "s" if number_of_minutes > 1 else "")
+    seconds_string = "{} second{}".format(number_of_seconds, "s" if number_of_seconds > 1 else "")
+
+    return "{}{}{}{}{}{}{}".format(
+        days_string if number_of_days > 0 else "",
+        "" if number_of_days == 0 or (number_of_hours == 0 and number_of_minutes == 0) else (
+            " and " if (number_of_hours > 0 and number_of_minutes == 0 and number_of_seconds == 0) or (number_of_hours == 0 and number_of_minutes > 0 and number_of_seconds == 0) else ", "
+        ),
+        hours_string if number_of_hours > 0 else "",
+        "" if number_of_hours == 0 or number_of_minutes == 0 else (
+            " and " if number_of_minutes > 0 and number_of_seconds == 0 else ", "
+        ),
+        minutes_string if number_of_minutes > 0 else "",
+        " and " if number_of_seconds > 0 and (number_of_minutes > 0 or number_of_hours > 0 or number_of_days > 0) else "",
+        seconds_string if number_of_seconds > 0 else ""
+    )


### PR DESCRIPTION
I've added a function for turning seconds into a human readable string. I debated whether to put this into core.utils or core.date, but chose the latter since it's related to time. I also made corrections to a lot of the docstrings.

Signed-off-by: Scott Rushworth <openhab@5iver.com>