### PR TITLE
Update date.py

### DIFF
--- a/Core/automation/lib/python/core/date.py
+++ b/Core/automation/lib/python/core/date.py
@@ -57,7 +57,7 @@ __all__ = [
     "format_date",
     "days_between", "hours_between", "minutes_between", "seconds_between",
     "to_java_zoneddatetime", "to_java_calendar", "to_python_datetime",
-    "to_joda_datetime", "str_to_python_datetime", "millis", "joda_now", "elapsed"
+    "to_joda_datetime", "millis", "joda_now", "elapsed"
 ]
 
 

--- a/Core/automation/lib/python/core/date.py
+++ b/Core/automation/lib/python/core/date.py
@@ -414,7 +414,7 @@ def elapsed(start, end=joda_now(), format='digital'):
         start:  Start time in any datetime type or joda zdtt string (Required)
         end:    End time, optional. If not included the current time will be used
         format: 'digital' - Returns string '(-)HH:MM:SS' or '(-)Dd HH:MM:SS' [DEFAULT]
-                'text'    - Returns human readable string '2 days, 3 hours, 45 minutes'
+                'text'    - Returns human readable string '2 days, 3 hours and 45 minutes'
                 'seconds' - Returns the seconds as a float (with ms precision)
     
     Returns:
@@ -442,7 +442,7 @@ def elapsed(start, end=joda_now(), format='digital'):
     end_pdt = to_python_datetime(end)
     td = (end_pdt - start_pdt)          # Total time delay (as timedelta)
 
-    ts = e_seconds = td.total_seconds() # Retains ms precision
+    ts = e_seconds = td.total_seconds() # Retains ms precision (total seconds)
     sign = '-' if (ts < 0) else ''      # Get the sign of 'ts'          
     ts = int(abs(ts))                   # Make 'ts' a positive integer
 

--- a/Core/automation/lib/python/core/date.py
+++ b/Core/automation/lib/python/core/date.py
@@ -1,18 +1,13 @@
 """
 This module provides functions for date and time conversions.
-
 Types
 =====
-
     It is recommended that you use ``java.time.ZonedDateTime`` for all
     operations involving dates or ``DateTime`` Items. See the documentation for
     `java.time.ZonedDateTime <https://docs.oracle.com/javase/8/docs/api/java/time/ZonedDateTime.html>`_
     for more information about its useage.
-
     The functions in this module can accept any of the following date types:
-
     .. code-block::
-
         java.time.ZonedDateTime
         java.time.LocalDateTime
         java.util.Calendar
@@ -22,12 +17,11 @@ Types
         org.eclipse.smarthome.core.library.types.DateTimeType
         org.openhab.core.library.types.DateTimeType
         DateTimeFormatter.ISO_ZONED_DATE_TIME (String)
-
 Functions
 =========
 """
 
-import sys
+import re, sys
 import time, datetime
 
 if 'org.eclipse.smarthome.automation' in sys.modules or 'org.openhab.core.automation' in sys.modules:
@@ -64,23 +58,18 @@ __all__ = [
 def format_date(value, format_string="yyyy-MM-dd'T'HH:mm:ss.SSxx"):
     """
     Returns string of ``value`` formatted according to ``format_string``.
-
     This function can be used when updating Items in openHAB or to format any
     date value for output. The default format string follows the same ISO8601
     format used in openHAB.
-
     Examples:
         .. code-block::
-
             sendCommand("date_item", format_date(date_value))
             log.info("The time is currently: {}".format(format_date(ZonedDateTime.now())))
-
     Arguments:
         value: Any supported date value
         format_string (str): Pattern to format ``value`` with.
             See `java.time.format.DateTimeFormatter <https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html>`_
             for format string tokens.
-
     Returns:
         A string representation of ``value`` according to ``format_string``.
         If ``value`` does not have timezone information, the system default
@@ -92,12 +81,9 @@ def days_between(value_from, value_to, calendar_days=False):
     """
     Returns the number of days between ``value_from`` and ``value_to``.
     Will return a negative number if ``value_from`` is after ``value__to``.
-
     Examples:
         .. code-block::
-
             span_days = days_between(items["date_item"], ZonedDateTime.now())
-
     Arguments:
         value_from: Value to start from
         value_to: Value to measure to
@@ -113,12 +99,9 @@ def hours_between(value_from, value_to):
     """
     Returns the number of hours between ``value_from`` and ``value_to``.
     Will return a negative number if ``value_from`` is after ``value__to``.
-
     Examples:
         .. code-block::
-
             span_hours = hours_between(items["date_item"], ZonedDateTime.now())
-
     Arguments:
         value_from: Value to start from
         value_to: Value to measure to
@@ -129,12 +112,9 @@ def minutes_between(value_from, value_to):
     """
     Returns the number of minutes between ``value_from`` and ``value_to``.
     Will return a negative number if ``value_from`` is after ``value__to``.
-
     Examples:
         .. code-block::
-
             span_minutes = minutes_between(items["date_item"], ZonedDateTime.now())
-
     Arguments:
         value_from: Value to start from
         value_to: Value to measure to
@@ -145,12 +125,9 @@ def seconds_between(value_from, value_to):
     """
     Returns the number of seconds between ``value_from`` and ``value_to``.
     Will return a negative number if ``value_from`` is after ``value__to``.
-
     Examples:
         .. code-block::
-
             span_seconds = seconds_between(items["date_item"], ZonedDateTime.now())
-
     Arguments:
         value_from: Value to start from
         value_to: Value to measure to
@@ -160,19 +137,14 @@ def seconds_between(value_from, value_to):
 def to_java_zoneddatetime(value):
     """
     Converts any of the supported date types to ``java.time.ZonedDateTime``.
-
     Examples:
         .. code-block::
-
             java_time = to_java_zoneddatetime(items["date_item"])
-
     Arguments:
         value: Any supported date value
-
     Returns:
         A ``java.time.ZonedDateTime`` representing ``value``. If ``value``
         does not have timezone information, the system default will be used.
-
     Raises:
         DateTimeParseException: If ``value`` is a string and can't be parsed
         TypeError: If the type of ``value`` is not supported by this module
@@ -221,19 +193,14 @@ def to_java_zoneddatetime(value):
 def to_python_datetime(value):
     """
     Converts any of the supported date types to Python ``datetime.datetime``.
-
     Examples:
         .. code-block::
-
             python_time = to_python_datetime(items["date_item"])
-
     Arguments:
         value: Any supported date value
-
     Returns:
         A Python ``datetime.datetime`` representing ``value``. If ``value``
         does not have timezone information, the system default will be used.
-
     Raises:
         TypeError: If the type of ``value`` is not supported by this module
     """
@@ -257,7 +224,6 @@ class _pythonTimezone(datetime.tzinfo):
     def __init__(self, offset=0, name=""):
         """
         Python tzinfo with ``offset`` in minutes and name ``name``.
-
         Arguments:
             offset (int): Timezone offset from UTC in minutes.
             name (str): Display name of this instance.
@@ -277,20 +243,15 @@ class _pythonTimezone(datetime.tzinfo):
 def to_joda_datetime(value):
     """
     Converts any of the supported date types to ``org.joda.time.DateTime``.
-
     Examples:
         .. code-block::
-
             joda_time = to_joda_datetime(items["date_item"])
-
     Arguments:
         value: Any supported date value
-
     Returns:
         | An ``org.joda.time.DateTime`` representing ``value``.
         | If ``value`` does not have timezone information, the system default
           will be used.
-
     Raises:
         TypeError: If type of ``value`` is not suported by this package.
     """
@@ -298,7 +259,7 @@ def to_joda_datetime(value):
         return value
 
     value_zoneddatetime = to_java_zoneddatetime(value)
-    value_zoneId = value_zoneddatetime.getZone().getId().replace('GMT','')
+    value_zoneId = value_zoneddatetime.getZone().getId()
     return DateTime(
         value_zoneddatetime.toInstant().toEpochMilli(),
         DateTimeZone.forID(value_zoneId)
@@ -307,19 +268,14 @@ def to_joda_datetime(value):
 def to_java_calendar(value):
     """
     Converts any of the supported date types to ``java.util.Calendar``.
-
     Examples:
         .. code-block::
-
             calendar_time = to_java_calendar(items["date_item"])
-
     Arguments:
         value: Any supported date value
-
     Returns:
         A ``java.util.Calendar`` representing ``value``. If ``value`` does not
         have timezone information, the system default will be used.
-
     Raises:
         TypeError: If type of ``value`` is not supported by this package.
     """
@@ -327,7 +283,10 @@ def to_java_calendar(value):
         return value
 
     value_zoneddatetime = to_java_zoneddatetime(value)
-    new_calendar = Calendar.getInstance(TimeZone.getTimeZone(value_zoneddatetime.getZone().getId()))
+    value_zoneId = value_zoneddatetime.getZone().getId()
+    if re.match(r"[-+][0-2][\d]:[0-5][\d]", value_zoneId): # Match to '+HH:MM'
+        value_zoneId = 'GMT' + value_zoneId                # Convert to 'GMT+HH:MM'
+    new_calendar = Calendar.getInstance(TimeZone.getTimeZone(value_zoneId))
     new_calendar.set(Calendar.YEAR, value_zoneddatetime.getYear())
     new_calendar.set(Calendar.MONTH, value_zoneddatetime.getMonthValue() - 1)
     new_calendar.set(Calendar.DAY_OF_MONTH, value_zoneddatetime.getDayOfMonth())
@@ -340,16 +299,12 @@ def to_java_calendar(value):
 def human_readable_seconds(seconds):
     """
     Converts seconds into a human readable string of days, hours, minutes and seconds.
-
     Examples:
         .. code-block::
-
             message = human_readable_seconds(55555)
             # 15 hours, 25 minutes and 55 seconds
-
     Arguments:
         seconds: The number of seconds
-
     Returns:
         string: A string in the format ``{} days, {} hours, {} minutes and {} seconds``
     """
@@ -419,20 +374,15 @@ def elapsed(start, end=joda_now(), format='digital'):
     
     Returns:
         (see args)
-
     Code Block:
-
         from personal.<this_script> import elapsed, joda_now
-
         example.log.info("Elapsed: {}".format(elapsed(items.SomeItem, joda_now(True))))  
         example.log.info("Elapsed: {}".format(elapsed(items.SomeItem, joda_now(), format='text')))  
         example.log.info("Elapsed: {}".format(elapsed(items.SomeItem, joda_now(), format='seconds')))  
-
         Output:
         Elapsed: 405d 13:37:17
         Elapsed: 405 days, 13 hours and 37 minutes
         Elapsed: 35041036.273
-
     """
     e_digital = '00:00:00'      
     e_text    = '0 seconds'

--- a/Core/automation/lib/python/core/date.py
+++ b/Core/automation/lib/python/core/date.py
@@ -21,6 +21,7 @@ Types
         datetime.datetime (Python)
         org.eclipse.smarthome.core.library.types.DateTimeType
         org.openhab.core.library.types.DateTimeType
+        DateTimeFormatter.ISO_ZONED_DATE_TIME (String)
 
 Functions
 =========
@@ -173,11 +174,12 @@ def to_java_zoneddatetime(value):
         does not have timezone information, the system default will be used.
 
     Raises:
+        DateTimeParseException: If ``value`` is a string and can't be parsed
         TypeError: If the type of ``value`` is not supported by this module
     """
-    # Joda DateTime String
+    # org.joda.time.DateTime String
     if isinstance(value, basestring):
-        value = str_to_java_zoneddatetime(value)
+        return ZonedDateTime.parse(value)
     if isinstance(value, ZonedDateTime):
         return value
     timezone_id = ZoneId.systemDefault()
@@ -235,9 +237,6 @@ def to_python_datetime(value):
     Raises:
         TypeError: If the type of ``value`` is not supported by this module
     """
-    # Joda DateTime String
-    if isinstance(value, basestring):
-        value = str_to_java_zoneddatetime(value)
     if isinstance(value, datetime.datetime):
         return value
 
@@ -295,9 +294,6 @@ def to_joda_datetime(value):
     Raises:
         TypeError: If type of ``value`` is not suported by this package.
     """
-    # Joda DateTime String
-    if isinstance(value, basestring):
-        value = str_to_java_zoneddatetime(value)
     if isinstance(value, DateTime):
         return value
 
@@ -380,44 +376,6 @@ def human_readable_seconds(seconds):
         " and " if number_of_seconds > 0 and (number_of_minutes > 0 or number_of_hours > 0 or number_of_days > 0) else "",
         seconds_string if number_of_seconds > 0 else ""
     )
-
-def str_to_python_datetime(time_str):
-    """
-    Convert a Joda DateTime String to a python datetime object
-
-    Arguments:
-        time_str: string representation of joda zoned datetimetype
-                  '2019-09-03T15:22:33.650-05:00'
-
-    Returns:           
-        datetime.datetime: Timezone aware python datetime object
-        (If there is an exception while converting, None is returned)
-    """
-    try:
-        naive_time = time_str[:23]                  # removes '-05:00' (TZ) from joda zdtt str
-        tz_hr, tz_min = time_str[23:].split(':')    # Splits TZ into hr, min
-        offset = int(tz_hr) * 60 + int(tz_min)      # Gets minutes of offset
-        naive_pdt = datetime.datetime.strptime(naive_time, '%Y-%m-%dT%H:%M:%S.%f')
-        return naive_pdt.replace(tzinfo=_pythonTimezone(offset))
-    except:
-        return None
-
-def str_to_java_zoneddatetime(time_str):
-    """
-    Convert a Joda DateTime String to a Java ZonedDateTime object
-
-    Arguments:
-        time_str: string representation of joda datetime type
-                  '2019-09-03T15:22:33.650-05:00'
-
-    Returns:           
-        ZonedDateTime: Java ZonedDateTime object
-        (If there is an exception while converting, None is returned)
-    """
-    try:
-        return ZonedDateTime.parse(time_str)
-    except:
-        return None
 
 def millis():
     """

--- a/Core/automation/lib/python/core/date.py
+++ b/Core/automation/lib/python/core/date.py
@@ -424,8 +424,8 @@ def elapsed(start, end=joda_now(), format='digital'):
 
         from personal.<this_script> import elapsed, joda_now
 
-        example.log.info("Elapsed: {}".format(elapsed(items.SomeItem, joda_now())))  
-        example.log.info("Elapsed: {}".format(elapsed(items.SomeItem, joda_now(False), format='text')))  
+        example.log.info("Elapsed: {}".format(elapsed(items.SomeItem, joda_now(True))))  
+        example.log.info("Elapsed: {}".format(elapsed(items.SomeItem, joda_now(), format='text')))  
         example.log.info("Elapsed: {}".format(elapsed(items.SomeItem, joda_now(), format='seconds')))  
 
         Output:

--- a/Core/automation/lib/python/core/date.py
+++ b/Core/automation/lib/python/core/date.py
@@ -417,7 +417,7 @@ def joda_now(string=False):
     else: 
         return to_joda_datetime(ZonedDateTime.now())
 
-def elapsed(start, end=joda_now(), format='digital'):
+def elapsed(start, end=None, format='digital'):
     """
     Arguments:
         start:  Start time in any datetime type or joda zdtt string (Required)
@@ -445,6 +445,8 @@ def elapsed(start, end=joda_now(), format='digital'):
     e_text    = '0 seconds'
     e_seconds = 0.0
 
+    if end == None: end = joda_now()    # Make end time the current time
+    
     start_pdt = to_python_datetime(start)
     end_pdt = to_python_datetime(end)
     td = (end_pdt - start_pdt)          # Total time delay (as timedelta)

--- a/Core/automation/lib/python/core/date.py
+++ b/Core/automation/lib/python/core/date.py
@@ -1,13 +1,18 @@
 """
 This module provides functions for date and time conversions.
+
 Types
 =====
+
     It is recommended that you use ``java.time.ZonedDateTime`` for all
     operations involving dates or ``DateTime`` Items. See the documentation for
     `java.time.ZonedDateTime <https://docs.oracle.com/javase/8/docs/api/java/time/ZonedDateTime.html>`_
     for more information about its useage.
+
     The functions in this module can accept any of the following date types:
+
     .. code-block::
+
         java.time.ZonedDateTime
         java.time.LocalDateTime
         java.util.Calendar
@@ -17,6 +22,7 @@ Types
         org.eclipse.smarthome.core.library.types.DateTimeType
         org.openhab.core.library.types.DateTimeType
         DateTimeFormatter.ISO_ZONED_DATE_TIME (String)
+
 Functions
 =========
 """
@@ -58,18 +64,23 @@ __all__ = [
 def format_date(value, format_string="yyyy-MM-dd'T'HH:mm:ss.SSxx"):
     """
     Returns string of ``value`` formatted according to ``format_string``.
+
     This function can be used when updating Items in openHAB or to format any
     date value for output. The default format string follows the same ISO8601
     format used in openHAB.
+
     Examples:
         .. code-block::
+
             sendCommand("date_item", format_date(date_value))
             log.info("The time is currently: {}".format(format_date(ZonedDateTime.now())))
+
     Arguments:
         value: Any supported date value
         format_string (str): Pattern to format ``value`` with.
             See `java.time.format.DateTimeFormatter <https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html>`_
             for format string tokens.
+
     Returns:
         A string representation of ``value`` according to ``format_string``.
         If ``value`` does not have timezone information, the system default
@@ -81,9 +92,12 @@ def days_between(value_from, value_to, calendar_days=False):
     """
     Returns the number of days between ``value_from`` and ``value_to``.
     Will return a negative number if ``value_from`` is after ``value__to``.
+
     Examples:
         .. code-block::
+
             span_days = days_between(items["date_item"], ZonedDateTime.now())
+
     Arguments:
         value_from: Value to start from
         value_to: Value to measure to
@@ -99,9 +113,12 @@ def hours_between(value_from, value_to):
     """
     Returns the number of hours between ``value_from`` and ``value_to``.
     Will return a negative number if ``value_from`` is after ``value__to``.
+
     Examples:
         .. code-block::
+
             span_hours = hours_between(items["date_item"], ZonedDateTime.now())
+
     Arguments:
         value_from: Value to start from
         value_to: Value to measure to
@@ -112,9 +129,12 @@ def minutes_between(value_from, value_to):
     """
     Returns the number of minutes between ``value_from`` and ``value_to``.
     Will return a negative number if ``value_from`` is after ``value__to``.
+
     Examples:
         .. code-block::
+
             span_minutes = minutes_between(items["date_item"], ZonedDateTime.now())
+
     Arguments:
         value_from: Value to start from
         value_to: Value to measure to
@@ -125,9 +145,12 @@ def seconds_between(value_from, value_to):
     """
     Returns the number of seconds between ``value_from`` and ``value_to``.
     Will return a negative number if ``value_from`` is after ``value__to``.
+
     Examples:
         .. code-block::
+
             span_seconds = seconds_between(items["date_item"], ZonedDateTime.now())
+
     Arguments:
         value_from: Value to start from
         value_to: Value to measure to
@@ -137,14 +160,19 @@ def seconds_between(value_from, value_to):
 def to_java_zoneddatetime(value):
     """
     Converts any of the supported date types to ``java.time.ZonedDateTime``.
+
     Examples:
         .. code-block::
+
             java_time = to_java_zoneddatetime(items["date_item"])
+
     Arguments:
         value: Any supported date value
+
     Returns:
         A ``java.time.ZonedDateTime`` representing ``value``. If ``value``
         does not have timezone information, the system default will be used.
+
     Raises:
         DateTimeParseException: If ``value`` is a string and can't be parsed
         TypeError: If the type of ``value`` is not supported by this module
@@ -193,14 +221,19 @@ def to_java_zoneddatetime(value):
 def to_python_datetime(value):
     """
     Converts any of the supported date types to Python ``datetime.datetime``.
+
     Examples:
         .. code-block::
+
             python_time = to_python_datetime(items["date_item"])
+
     Arguments:
         value: Any supported date value
+
     Returns:
         A Python ``datetime.datetime`` representing ``value``. If ``value``
         does not have timezone information, the system default will be used.
+
     Raises:
         TypeError: If the type of ``value`` is not supported by this module
     """
@@ -224,6 +257,7 @@ class _pythonTimezone(datetime.tzinfo):
     def __init__(self, offset=0, name=""):
         """
         Python tzinfo with ``offset`` in minutes and name ``name``.
+
         Arguments:
             offset (int): Timezone offset from UTC in minutes.
             name (str): Display name of this instance.
@@ -243,15 +277,20 @@ class _pythonTimezone(datetime.tzinfo):
 def to_joda_datetime(value):
     """
     Converts any of the supported date types to ``org.joda.time.DateTime``.
+
     Examples:
         .. code-block::
+
             joda_time = to_joda_datetime(items["date_item"])
+
     Arguments:
         value: Any supported date value
+
     Returns:
         | An ``org.joda.time.DateTime`` representing ``value``.
         | If ``value`` does not have timezone information, the system default
           will be used.
+
     Raises:
         TypeError: If type of ``value`` is not suported by this package.
     """
@@ -259,7 +298,7 @@ def to_joda_datetime(value):
         return value
 
     value_zoneddatetime = to_java_zoneddatetime(value)
-    value_zoneId = value_zoneddatetime.getZone().getId()
+    value_zoneId = value_zoneddatetime.getZone().getId().replace('GMT','')
     return DateTime(
         value_zoneddatetime.toInstant().toEpochMilli(),
         DateTimeZone.forID(value_zoneId)
@@ -268,14 +307,19 @@ def to_joda_datetime(value):
 def to_java_calendar(value):
     """
     Converts any of the supported date types to ``java.util.Calendar``.
+
     Examples:
         .. code-block::
+
             calendar_time = to_java_calendar(items["date_item"])
+
     Arguments:
         value: Any supported date value
+
     Returns:
         A ``java.util.Calendar`` representing ``value``. If ``value`` does not
         have timezone information, the system default will be used.
+
     Raises:
         TypeError: If type of ``value`` is not supported by this package.
     """
@@ -299,12 +343,16 @@ def to_java_calendar(value):
 def human_readable_seconds(seconds):
     """
     Converts seconds into a human readable string of days, hours, minutes and seconds.
+
     Examples:
         .. code-block::
+
             message = human_readable_seconds(55555)
             # 15 hours, 25 minutes and 55 seconds
+
     Arguments:
         seconds: The number of seconds
+
     Returns:
         string: A string in the format ``{} days, {} hours, {} minutes and {} seconds``
     """
@@ -331,6 +379,7 @@ def human_readable_seconds(seconds):
         " and " if number_of_seconds > 0 and (number_of_minutes > 0 or number_of_hours > 0 or number_of_days > 0) else "",
         seconds_string if number_of_seconds > 0 else ""
     )
+
 
 def millis():
     """
@@ -374,6 +423,7 @@ def elapsed(start, end=joda_now(), format='digital'):
     
     Returns:
         (see args)
+
     Code Block:
         from personal.<this_script> import elapsed, joda_now
         example.log.info("Elapsed: {}".format(elapsed(items.SomeItem, joda_now(True))))  

--- a/Core/automation/lib/python/core/date.py
+++ b/Core/automation/lib/python/core/date.py
@@ -406,6 +406,11 @@ def joda_now(string=False):
         DateTime: If 'string' == False, returns a Joda DateTime object
         string: If 'string' == True, returns string representation of 
                 Joda DateTime ('2019-09-03T15:22:33.650+05:00')
+    
+    Code Block:
+        from core.date import joda_now
+        
+        events.postUpdate("SomeDateTimeItem", joda_now(True))
     """
     if string == True:
         return str(to_joda_datetime(ZonedDateTime.now()))
@@ -425,10 +430,12 @@ def elapsed(start, end=joda_now(), format='digital'):
         (see args)
 
     Code Block:
-        from personal.<this_script> import elapsed, joda_now
-        example.log.info("Elapsed: {}".format(elapsed(items.SomeItem, joda_now(True))))  
-        example.log.info("Elapsed: {}".format(elapsed(items.SomeItem, joda_now(), format='text')))  
-        example.log.info("Elapsed: {}".format(elapsed(items.SomeItem, joda_now(), format='seconds')))  
+        from core.date import elapsed, joda_now
+        
+        example.log.info("Elapsed: {}".format(elapsed(items.SomeDateTimeItem)))  
+        example.log.info("Elapsed: {}".format(elapsed(items.SomeDateTimeItem, joda_now(True), format='text')))  
+        example.log.info("Elapsed: {}".format(elapsed(items.SomeDateTimeItem, joda_now(), format='seconds')))  
+        
         Output:
         Elapsed: 405d 13:37:17
         Elapsed: 405 days, 13 hours and 37 minutes

--- a/Core/automation/lib/python/core/date.py
+++ b/Core/automation/lib/python/core/date.py
@@ -175,15 +175,15 @@ def to_java_zoneddatetime(value):
     Raises:
         TypeError: If the type of ``value`` is not supported by this module
     """
+    # Joda DateTime String
+    if isinstance(value, basestring):
+        value = str_to_java_zoneddatetime(value)
     if isinstance(value, ZonedDateTime):
         return value
     timezone_id = ZoneId.systemDefault()
     # java.time.LocalDateTime
     if isinstance(value, LocalDateTime):
         return value.atZone(timezone_id)
-    # Joda DateTime String
-    if isinstance(value, basestring):
-        value = str_to_python_datetime(value)
     # python datetime
     if isinstance(value, datetime.datetime):
         if value.tzinfo is not None:
@@ -237,7 +237,7 @@ def to_python_datetime(value):
     """
     # Joda DateTime String
     if isinstance(value, basestring):
-        value = str_to_python_datetime(value)
+        value = str_to_java_zoneddatetime(value)
     if isinstance(value, datetime.datetime):
         return value
 
@@ -297,15 +297,15 @@ def to_joda_datetime(value):
     """
     # Joda DateTime String
     if isinstance(value, basestring):
-        value = str_to_python_datetime(value)
+        value = str_to_java_zoneddatetime(value)
     if isinstance(value, DateTime):
         return value
 
     value_zoneddatetime = to_java_zoneddatetime(value)
-    value_zoneID = value_zoneddatetime.getZone().getId().replace('GMT','')
+    value_zoneId = value_zoneddatetime.getZone().getId().replace('GMT','')
     return DateTime(
         value_zoneddatetime.toInstant().toEpochMilli(),
-        DateTimeZone.forID(value_zoneID)
+        DateTimeZone.forID(value_zoneId)
     )
 
 def to_java_calendar(value):
@@ -383,7 +383,7 @@ def human_readable_seconds(seconds):
 
 def str_to_python_datetime(time_str):
     """
-    Convert a Joda ZonedDateTime String to a python datetime object
+    Convert a Joda DateTime String to a python datetime object
 
     Arguments:
         time_str: string representation of joda zoned datetimetype
@@ -401,7 +401,24 @@ def str_to_python_datetime(time_str):
         return naive_pdt.replace(tzinfo=_pythonTimezone(offset))
     except:
         return None
-    
+
+def str_to_java_zoneddatetime(time_str):
+    """
+    Convert a Joda DateTime String to a Java ZonedDateTime object
+
+    Arguments:
+        time_str: string representation of joda datetime type
+                  '2019-09-03T15:22:33.650-05:00'
+
+    Returns:           
+        ZonedDateTime: Java ZonedDateTime object
+        (If there is an exception while converting, None is returned)
+    """
+    try:
+        return ZonedDateTime.parse(time_str)
+    except:
+        return None
+
 def millis():
     """
     Get the current time in millis (unix epoch) as an int to 
@@ -415,18 +432,18 @@ def millis():
     """
     return int(round(time.time() * 1000))
 
-def joda_now(string=True):
+def joda_now(string=False):
     """
-    Get the Joda DateTime as a string or an object to be used in 
-    updating an OpenHAB DateTime item
+    Get the Joda DateTime object or Joda DateTime
+    string to be used in updating OpenHAB DateTime items
     
     Arguments:
-        string: Boolean, defaults to True
+        string: Boolean, defaults to False
     
     Returns:
-        string: If 'string' == True, returns string representation of 
-                Joda DateTime ('2019-09-03T15:22:33.650-05:00')
         DateTime: If 'string' == False, returns a Joda DateTime object
+        string: If 'string' == True, returns string representation of 
+                Joda DateTime ('2019-09-03T15:22:33.650+05:00')
     """
     if string == True:
         return str(to_joda_datetime(ZonedDateTime.now()))


### PR DESCRIPTION
First, I found an issue in the to_joda_datetime() function where passing it a python datetime.datetime object would throw an error: 
IllegalArgumentException: java.lang.IllegalArgumentException: The datetime zone id 'GMT-05:00' is not recognised
I believe this is because java ZoneOffset.getId is expecting just "-05:00" without the 'GMT', and is "incompatible" with the python zone ID.  I modified the code slightly and replace "GMT" with "", and it clears up the problem for me (line 305-308), and shouldn't cause any side effects.

Also, I added a millis() function to get millis past unix epoch, a joda_now() function to simplify getting the current joda datetime string or object, an elapsed function to get various formats of elapsed time between two datetime objects or joda datetime strings, and a str_to_python_datetime() function to allow passing a joda datetime string into all of the other conversion functions within this library.

Note: I did this because I have all of these functions in a separate personal library and I wanted to combine them, and I also wanted to learn about github and the fork/pull process.  Please let me know if I'm breaking some kind of etiquette rules here! Thanks.

I know there's a change forthcoming on the human_readable_seconds() function to convert the argument to a integer, and I'm interested to see if my fork gets that update or if a fork gets orphaned at the point where it is "forked".  (Lack of github knowledge on my part).