### PR TITLE
Add .pylintrc for OHCONF and update VSC docs

### DIFF
--- a/OHCONF.pylintrc
+++ b/OHCONF.pylintrc
@@ -37,6 +37,10 @@ disable=
     anomalous-unicode-escape-in-string,
     global-statement,
     deprecated-method,                 # log.warn
+    dangerous-default-value,
+    arguments-differ,
+    redefined-builtin,
+    redefined-outer-name,
 
 
 [TYPECHECK]
@@ -44,11 +48,10 @@ disable=
 ignored-modules=
     # Java packages
     java,
-    org.joda.time,
+    org,
     # openHAB packages and classes
     events,
     # Helper Libraries modules
-    core,
     core.jsr223,
     core.actions,
     community,

--- a/OHCONF.pylintrc
+++ b/OHCONF.pylintrc
@@ -1,0 +1,123 @@
+[MASTER]
+
+jobs=2      # use 2 cores
+#jobs=4      # use 4 cores
+#jobs=8      # use 8 cores
+
+
+[MESSAGES CONTROL]
+
+enable=
+    E,
+    F,
+
+    # VSCode defaults - https://code.visualstudio.com/docs/python/linting#_default-pylint-rules
+    unreachable,
+    duplicate-key,
+    unnecessary-semicolon,
+    global-variable-not-assigned,
+    unused-variable,
+    binary-op-exception,
+    bad-format-string,
+    anomalous-backslash-in-string,
+    bad-open-mode
+
+disable=
+    C,
+    R,
+    reimported,
+    missing-docstring,
+    line-too-long,
+    logging-format-interpolation,
+    bare-except,
+    broad-except,
+    pointless-string-statement,
+    unused-argument,
+    wrong-import-position,
+    anomalous-unicode-escape-in-string,
+    global-statement,
+    deprecated-method,                 # log.warn
+
+
+[TYPECHECK]
+
+ignored-modules=
+    # Java packages
+    java,
+    org.joda.time,
+    # openHAB packages and classes
+    events,
+    # Helper Libraries modules
+    core,
+    core.jsr223,
+    core.actions,
+    community,
+    personal,
+    configuration,
+
+generated-members=
+    # added by `rules` decorator
+    log,
+    UID,
+    # added by `when` decorator
+    triggers
+
+
+[VARIABLES]
+
+additional-builtins=
+    reload,             # Jython module reloader
+
+    # Default Preset
+    State,
+    Command,
+    DateTime,
+    LocalTime,
+    StringUtils,
+    URLEncoder,
+    FileUtils,
+    FilenameUtils,
+    File,
+    UnDefType,
+    NULL,
+    UNDEF,
+    IncreaseDecreaseType,
+    DECREASE,
+    INCREASE,
+    OnOffType,
+    ON,
+    OFF,
+    OpenCloseType,
+    OPEN,
+    CLOSED,
+    StopMoveType,
+    STOP,
+    MOVE,
+    RewindFastforwardType,
+    REWIND,
+    FASTFORWARD,
+    NextPreviousType,
+    NEXT,
+    PREVIOUS,
+    PlayPauseType,
+    PLAY,
+    PAUSE,
+    UpDownType,
+    UP,
+    DOWN,
+    DecimalType,
+    QuantityType,
+    HSBType,
+    PercentType,
+    PointType,
+    StringType,
+    StringListType,
+    RawType,
+    items,
+    itemRegistry,
+    ir,
+    things,
+    rules,
+    scriptExtension,
+    se,
+    events

--- a/Sphinx/Getting Started/VS Code.rst
+++ b/Sphinx/Getting Started/VS Code.rst
@@ -19,43 +19,11 @@ ENV File
     This will allow ``pylint`` to see any packages or modules in that directory and no longer
     show import errors for them.
 
-Exclude Helper Libraries
-========================
+``.pylintrc`` File
+==================
 
-    If you don't already have an ``{OH_CONF}/.vscode/settings.json`` file, create it and
-    add the following:
+    Copy the ``OHCONF.pylintrc`` file from the root of this repository into your openHAB conf
+    directory and rename it to ``.pylintrc``. It will prevent any openHAB or Java packages from
+    being listed as missing, as well as all objects from the Default Preset.
 
-    .. code-block:: JSON
-
-        {
-            "python.linting.ignorePatterns": [
-                "**/automation/**/python/core/**/*.py",
-                "**/automation/**/python/community/**/*.py"
-            ]
-        }
-
-    This will tell ``pylint`` to ignore all files in the Helper Libraries' ``core`` and
-    ``community`` directories, greatly reducing the number of errors you will see
-    because of openHAB packages it cannot import.
-
-pylint Directives
-=================
-
-    Lastly, you can use ``pylint`` directives if you want to disable the import error
-    messages in your files for the openHAB packages that it cannot import.
-
-    When importing packages or classes from openHAB:
-
-    .. code-block::
-
-        # pylint: disable=import-error
-        from org.openhab.core.library.items import SwitchItem
-        # pylint: enable=import-error
-
-    When importing ``scope`` from ``core.jsr223``:
-
-    .. code-block::
-
-        # pylint: disable=import-error, no-name-in-module
-        from core.jsr223 import scope
-        # pylint: enable=import-error, no-name-in-module
+    [``OHCONF.pylintrc``](https://github.com/openhab-scripters/openhab-helper-libraries/blob/master/.gitignore)


### PR DESCRIPTION
Add a `.pylintrc` for use in OHCONF directory and update VSC setup documentation in regards to how this changes setting that up for HL/JSR223 scripting.