### PR TITLE
log_traceback to decorate wrapper function correctly

### DIFF
--- a/Core/automation/lib/python/core/log.py
+++ b/Core/automation/lib/python/core/log.py
@@ -45,7 +45,7 @@ def log_traceback(fn):
     configuration.adminEmail variable is populated, the notification will be
     sent to that address. Otherwise, a broadcast notification will be sent.
     """
-    functools.wraps(fn)
+    @functools.wraps(fn)
     def wrapper(*args, **kwargs):
         try:
             return fn(*args, **kwargs)

--- a/Core/automation/lib/python/core/rules.py
+++ b/Core/automation/lib/python/core/rules.py
@@ -96,6 +96,7 @@ class _FunctionRule(SimpleRule):
                 name = "JSR223-Jython"
         self.name = name
         callback.log = logging.getLogger("{}.{}".format(LOG_PREFIX, name))
+        callback.name = name
         self.callback = log_traceback(callback)
         if description is not None:
             self.description = description


### PR DESCRIPTION
To my understanding, the code did not actually decorate the `wrapper` function at all. 

See https://docs.python.org/2/library/functools.html#functools.wraps

I haven't tested this in practice, should definitely be done to avoid any issues / unexpected changes in tracebacks. 

Signed-off-by: Sami Salonen <ssalonen@gmail.com>