### PR TITLE
Area T&A: Add override and lux antiflap support

### DIFF
--- a/Community/Area Triggers and Actions/automation/lib/python/community/area_triggers_and_actions/area_actions.py
+++ b/Community/Area Triggers and Actions/automation/lib/python/community/area_triggers_and_actions/area_actions.py
@@ -7,9 +7,10 @@ be overwritten during an upgrade. Instead, place them in the
 """
 __all__ = ['light_action', 'toggle_action']
 
-from core.jsr223.scope import events, items, PercentType, DecimalType, HSBType, ON, OFF
+from core.jsr223.scope import events, ir, items, PercentType, DecimalType, HSBType, ON, OFF, NULL
 from core.metadata import get_key_value
 from core.log import logging, LOG_PREFIX
+from org.eclipse.smarthome.core.items import ItemNotFoundException
 
 import configuration
 reload(configuration)
@@ -37,61 +38,55 @@ def light_action(item, active):
     #start_time = DateTime.now().getMillis()
     item_metadata = get_key_value(item.name, "area_triggers_and_actions", "modes", str(items["Mode"]))
     low_lux_trigger = item_metadata.get("low_lux_trigger", area_triggers_and_actions_dict["default_levels"]["low_lux_trigger"])
+
+    brightness_override_by_state = get_key_value(item.name, "area_triggers_and_actions", "brightness_override_by_state")
+    if brightness_override_by_state == {}:
+        brightness_override_by_state = True # turn on brightness_override_by_state by default if not configured
+
+    brightness = PercentType(str(item_metadata.get("brightness", area_triggers_and_actions_dict["default_levels"]["brightness"])))
     hue = DecimalType(item_metadata.get("hue", area_triggers_and_actions_dict["default_levels"]["hue"]))
     saturation = PercentType(str(item_metadata.get("saturation", area_triggers_and_actions_dict["default_levels"]["saturation"])))
-    brightness = PercentType(str(item_metadata.get("brightness", area_triggers_and_actions_dict["default_levels"]["brightness"])))
-    #log.warn("light_action: item.name [{}], active [{}], brightness [{}], lux [{}], low_lux_trigger [{}]".format(item.name, active, brightness, items[area_triggers_and_actions_dict["lux_item_name"]], low_lux_trigger))
+
     lux_item_name = area_triggers_and_actions_dict.get("lux_item_name")
-    if active and brightness > PercentType(0) and (True if lux_item_name is None else items[lux_item_name].intValue() <= low_lux_trigger):
-        if item.type == "Dimmer" or (item.type == "Group" and item.baseItem.type == "Dimmer"):
-            if item.state != brightness:
-                if item.state < PercentType(99):
-                    events.sendCommand(item, brightness)
-                    log.info(">>>>>>> {}: {}".format(item.name, brightness))
-                else:
-                    log.info("[{}]: dimmer was manually set > 98, so not adjusting".format(item.name))
-            else:
-                log.debug("[{}]: dimmer is already set to [{}], so not sending command".format(item.name, brightness))
-        elif item.type == "Color" or (item.type == "Group" and item.baseType == "Color"):
-            if item.state != HSBType(hue, saturation, brightness):
-                if item.state.brightness < PercentType(99):
-                    events.sendCommand(item, HSBType(hue, saturation, brightness))
-                    log.info(">>>>>>> {}: [{}]".format(item.name, HSBType(hue, saturation, brightness)))
-                else:
-                    log.info("[{}]: brightness was manually set > 98, so not adjusting".format(item.name))
-            else:
-                log.debug("[{}]: color is already set to [{}, {}, {}], so not sending command".format(item.name, hue, saturation, brightness))
-        elif item.type == "Switch" or (item.type == "Group" and item.baseItem.type == "Switch"):
-            if item.state == OFF:
-                events.sendCommand(item, ON)
-                log.info(">>>>>>> {}: ON".format(item.name))
-            else:
-                log.debug("[{}]: switch is already [ON], so not sending command".format(item.name))
+    if lux_item_name is not None and items[lux_item_name] == NULL:
+        log.debug("Lux item {} is reporting NULL".format(lux_item_name))
+    # item from inactive area or above lux threshold will be turned off
+    if not active or (lux_item_name is not None and items[lux_item_name] != NULL and items[lux_item_name].intValue() > low_lux_trigger):
+        brightness = PercentType(0)
+        hue = DecimalType(0)
+        saturation = PercentType(0)
+
+    # apply brightness override if available
+    brightness_override_item_name = get_key_value(item.name, "area_triggers_and_actions", "brightness_override_item_name")
+    if brightness_override_item_name != {}:
+        try:
+            brightness_override_item = ir.getItem(brightness_override_item_name)
+            if brightness_override_item.state is not NULL and 0 <= brightness_override_item.state.floatValue() <= 100:
+                brightness = brightness_override_item.state
+        except ItemNotFoundException:
+            log.warn("Configured brightness override item {} doesn't exist".format(brightness_override_item_name))
+        
+    #log.warn("light_action: item.name [{}], active [{}], brightness [{}], lux [{}], low_lux_trigger [{}]".format(item.name, active, brightness, items[area_triggers_and_actions_dict["lux_item_name"]], low_lux_trigger))
+    #apply newly determined brightness
+    if item.type == "Dimmer" or (item.type == "Group" and item.baseItem.type == "Dimmer"):
+        new_state = brightness
+        brightness_override_by_state = brightness_override_by_state and item.state != NULL and item.state >= PercentType(99)
+    elif item.type == "Color" or (item.type == "Group" and item.baseType == "Color"):
+        new_state = HSBType(hue, saturation, brightness)
+        brightness_override_by_state = brightness_override_by_state and item.state != NULL and item.state.brightness >= PercentType(99)
+    elif item.type == "Switch" or (item.type == "Group" and item.baseItem.type == "Switch"):
+        new_state = OFF if brightness == PercentType(0) else ON
+        brightness_override_by_state = False # switches can't support override by state since they only have 2 states
+    
+    if item.state != new_state:
+        if not brightness_override_by_state:
+            events.sendCommand(item, new_state)
+            log.info("{} {}: {}".format("<<<<<<<" if brightness == PercentType(0) else ">>>>>>>", item.name, new_state))
+        else:
+            log.info("[{}]: item was manually set > 98, so not adjusting".format(item.name))
     else:
-        if item.type == "Dimmer" or (item.type == "Group" and item.baseItem.type == "Dimmer"):
-            if item.state != PercentType(0):
-                if item.state < PercentType(99):
-                    events.sendCommand(item, PercentType(0))
-                    log.info("<<<<<<<<<<<<<<<<<<<<< {}: 0".format(item.name))
-                else:
-                    log.info("{}: dimmer was manually set > 98, so not adjusting".format(item.name))
-            else:
-                log.debug("[{}]: dimmer is already set to [0], so not sending command".format(item.name))
-        elif item.type == "Color" or (item.type == "Group" and item.baseType == "Color"):
-            if item.state != HSBType(DecimalType(0), PercentType(0), PercentType(0)):
-                if item.state.brightness < PercentType(99):
-                    events.sendCommand(item, "0, 0, 0")
-                    log.info("<<<<<<<<<<<<<<<<<<<<< {}: [0, 0, 0]".format(item.name))
-                else:
-                    log.info("{}: brightness was manually set > 98, so not adjusting".format(item.name))
-            else:
-                log.debug("[{}]: color is already set to [0, 0, 0], so not sending command".format(item.name))
-        elif item.type == "Switch" or (item.type == "Group" and item.baseItem.type == "Switch"):
-            if item.state == ON:
-                events.sendCommand(item, OFF)
-                log.info("<<<<<<<<<<<<<<<<<<<<< {}: OFF".format(item.name))
-            else:
-                log.debug("[{}]: switch is already set to [OFF], so not sending command".format(item.name))
+        log.debug("[{}]: item is already set to [{}], so not sending command".format(item.name, brightness))
+
     #log.warn("Test: light_action: {}: [{}]: time=[{}]".format(item.name, "ON" if active else "OFF", DateTime.now().getMillis() - start_time))
 
 def toggle_action(item, active):


### PR DESCRIPTION
1) Override
Honor an optional override item when determining action brightness.
Made existing mechanism for override by state of 99 or 100
configurable to allow turning it off when it doesn't apply. Refactored
light_action to eliminate duplicate code.
2) Lux antiflap
Add notion of configurable lux threshold buffer to handle flapping lux
sensor. As long as lux sensor reading variations stay within the buffer
size no new threshold breaches are detected avoiding resulting actions
to flap between on and off. Refactored to gracefully handle NULL items.

Signed-off-by: Mark Theiding <mark.theiding@gmail.com>