### PR TITLE
fix JythonTransform

### DIFF
--- a/Core/automation/jsr223/python/core/components/200_JythonTransform.py
+++ b/Core/automation/jsr223/python/core/components/200_JythonTransform.py
@@ -12,16 +12,19 @@ from core.log import logging, LOG_PREFIX
 TRANSFORMATION_CLASS = None
 
 try:
-    from org.openhab.core.transform import TransformationService
-    TRANSFORMATION_CLASS = "org.openhab.core.transform.TransformationService"
-except:
     from org.eclipse.smarthome.core.transform import TransformationService
+    from org.eclipse.smarthome.config.core import ConfigConstants
     TRANSFORMATION_CLASS = "org.eclipse.smarthome.core.transform.TransformationService"
+except:
+    from org.openhab.core.transform import TransformationService
+    from org.openhab.core.config.core import ConfigConstants
+    TRANSFORMATION_CLASS = "org.openhab.core.transform.TransformationService"
 
 try:
     class JythonTransformationService(TransformationService):
 
-        def transform(self, pathname, value):
+        def transform(self, function, value):
+            pathname = "{}/{}/{}".format(ConfigConstants.getConfigFolder(), TransformationService.TRANSFORM_FOLDER_NAME, function)
             with open(pathname, "r") as file_path:
                 code = file_path.read()
                 return eval(code, globals(), {'value': value})

--- a/Core/automation/lib/python/core/triggers.py
+++ b/Core/automation/lib/python/core/triggers.py
@@ -280,8 +280,8 @@ def when(target):
             raise ValueError(u"when: '{}' is not a valid Thing status".format(new_state))
         elif target_type == "Channel" and things.getChannel(ChannelUID(trigger_target)) is None:# returns null if Channel does not exist
             raise ValueError(u"when: '{}' could not be parsed because Channel '{}' does not exist".format(target, trigger_target))
-        elif target_type == "Channel" and things.getChannel(ChannelUID(trigger_target)).kind != ChannelKind.TRIGGER:
-            raise ValueError(u"when: '{}' could not be parsed because '{}' is not a trigger Channel".format(target, trigger_target))
+#       elif target_type == "Channel" and things.getChannel(ChannelUID(trigger_target)).kind != ChannelKind.TRIGGER:
+#           raise ValueError(u"when: '{}' could not be parsed because '{}' is not a trigger Channel".format(target, trigger_target))
         elif target_type == "System" and trigger_target != "started":# and trigger_target != "shuts down":
             raise ValueError(u"when: '{}' could not be parsed. trigger_target '{}' is invalid for target_type 'System'. The only valid trigger_type value is 'started'".format(target, target_type))# and 'shuts down'".format(target, target_type))
 


### PR DESCRIPTION
a) changed loading order of TransformationService since in (at least) OpenHAB 2.5.7 both org.openhab.core.transform.TransformationService and org.eclipse.smarthome.core.transform.TransformationService are available but the former is unused and isn't picked up by the component system

b) changed transform parameter "pathname" to "function" as in TransformationService and build "pathname" from config path + transform + function (shamelessly copied from AbstractFileTransformationService#getSourcePath)


