### PR TITLE
Enable unicode character handling without the hassle

### DIFF
--- a/Core/automation/lib/python/core/items.py
+++ b/Core/automation/lib/python/core/items.py
@@ -2,6 +2,8 @@
 This module allows runtime creation and removal of items. It will also remove
 any links from an Item before it is removed.
 """
+from __future__ import unicode_literals
+
 __all__ = ["add_item", "remove_item"]
 
 from core.jsr223.scope import scriptExtension, itemRegistry

--- a/Core/automation/lib/python/core/metadata.py
+++ b/Core/automation/lib/python/core/metadata.py
@@ -4,6 +4,8 @@ This module provides functions for manipulating Item Metadata.
 See the :ref:`Guides/Metadata:Metadata` guide for details on the metadata
 structure.
 """
+from __future__ import unicode_literals
+
 __all__ = [
     "get_all_namespaces",
     "get_metadata",

--- a/Core/automation/lib/python/core/utils.py
+++ b/Core/automation/lib/python/core/utils.py
@@ -2,6 +2,8 @@
 """
 This module provides miscellaneous utility functions that are used across the core packages and modules.
 """
+from __future__ import unicode_literals
+
 __all__ = [
     "validate_channel_uid",
     "validate_uid",


### PR DESCRIPTION
I'd like to propose this changes to handle unicode strings without the hassle.
It's very useful for situation where items are created via jython scripts, and item label suppose to be in the language that uses unicode characters (e.g. polish, german, etc.)
