### PR TITLE
Add high/low lux settings

### DIFF
--- a/Community/Area Triggers and Actions/automation/jsr223/python/community/area_triggers_and_actions/area_triggers.py
+++ b/Community/Area Triggers and Actions/automation/jsr223/python/community/area_triggers_and_actions/area_triggers.py
@@ -2,24 +2,25 @@
 This script provides a rule that triggers when an area trigger group changes
 state and another rule that adjusts the lights after a lux level change.
 """
-from threading import Timer
+from thread import start_new_thread
 
-from core.rules import rule
-from core.triggers import when
-from core.metadata import get_metadata, get_key_value, get_value
-from core.items import add_item
+#from org.joda.time import DateTime
 
 import configuration
 reload(configuration)
-from configuration import area_triggers_and_actions_dict
+from configuration import AREA_TRIGGERS_AND_ACTIONS_CONFIGURATION
 
 import community.area_triggers_and_actions
 reload(community.area_triggers_and_actions)
 from community.area_triggers_and_actions import start_action
 
-#from org.joda.time import DateTime
+from core.rules import rule
+from core.triggers import when
+from core.metadata import get_metadata, get_key_value
+from core.actions import PersistenceExtensions
 
-@rule("Area triggers")
+
+@rule("Area triggers", description="This rule will update the light level when the state of an area changes.")
 @when("Member of gArea_Trigger changed")
 def area_triggers(event):
     """
@@ -28,65 +29,83 @@ def area_triggers(event):
     specified in the metadata of each of the group's members will be executed
     using that Item. If the Item does not have an action function in its
     metadata, the default action function will be used from
-    ``configuration.area_triggers_and_actions_dict["default_action_function"]``.
+    ``configuration.AREA_TRIGGERS_AND_ACTIONS_CONFIGURATION["default_action_function"]``.
     If the trigger group has an action function in its metadata, that function
     will also be executed using the trigger group.
     """
     #start_time = DateTime.now().getMillis()
     if items["Mode"] != StringType("Security"):
-        area_triggers.log.debug("{}: [{}]".format(event.itemName, event.itemState))
+        area_triggers.log.debug(u"{}: '{}'".format(event.itemName, event.itemState))
         active = event.itemState in [ON, OPEN]
         action_groups = itemRegistry.getItems(event.itemName.replace("_Trigger", "_Action"))
         if action_groups:
-            action_group = action_groups[0]
-            #area_triggers.log.warn("Test: start loop: {}: [{}]: time=[{}]".format(event.itemName, event.itemState, DateTime.now().getMillis() - start_time))
-            for item in action_group.members:
-                action_function_names = get_key_value(item.name, "area_triggers_and_actions", "actions").keys()
-                if not action_function_names:
-                    action_function_names.append(area_triggers_and_actions_dict.get("default_action_function"))
-                for action_function_name in action_function_names:
-                    start_action(item, active, action_function_name)
-            #area_triggers.log.warn("Test: end loop: {}: [{}]: time=[{}]".format(event.itemName, event.itemState, DateTime.now().getMillis() - start_time))
-        else:
-            area_triggers.log.debug("No action group found for [{}]".format(event.itemName))
-        trigger_function_names = get_key_value(event.itemName, "area_triggers_and_actions", "actions").keys()
-        for trigger_function_name in trigger_function_names:
-            start_action(itemRegistry.getItem(event.itemName), active, trigger_function_name)
-    #area_triggers.log.warn("Test: {}: [{}]: time=[{}]".format(event.itemName, event.itemState, DateTime.now().getMillis() - start_time))
-
-if area_triggers_and_actions_dict.get("lux_item_name") and itemRegistry.getItems(area_triggers_and_actions_dict["lux_item_name"]):
-    @rule("Mode or lux change")
-    @when("Item {} changed".format(area_triggers_and_actions_dict["lux_item_name"]))
-    @when("Item Mode changed")
-    @when("System started")
-    def mode_or_lux_change(event):
-        """
-        This rule iterates through all triggering groups and replays all actions
-        for groups that are currently active, using the current mode and lux level.
-        """
-        #start_time = DateTime.now().getMillis()
-        mode_change_or_system_start = (event.itemName == "Mode") if event is not None else True
-        if not mode_change_or_system_start:
-            lux_current = items[area_triggers_and_actions_dict["lux_item_name"]]
-            lux_previous = event.oldItemState
-        spanned = False
-        # get a list of active trigger groups (or all of them, if system started)
-        for trigger_group in [group for group in itemRegistry.getItem("gArea_Trigger").members if (group.state in [ON, OPEN] if event is not None else True)]:
-            action_groups = itemRegistry.getItems(trigger_group.name.replace("_Trigger", "_Action"))
-            action_group = action_groups[0] if action_groups else None
-            if action_group:
+            for action_group in action_groups:# there will be only one
+                #area_triggers.log.warn(u"Test: start loop: itemName: '{}', itemState: '{}', time: '{}'".format(event.itemName, event.itemState, DateTime.now().getMillis() - start_time))
                 for item in action_group.members:
-                    low_lux_trigger = get_key_value(item.name, "area_triggers_and_actions", "modes", str(items["Mode"]), "low_lux_trigger") or area_triggers_and_actions_dict["default_levels"]["low_lux_trigger"]
-                    # replay actions for all lights on mode change and system start, or only the lights affected on a lux change
-                    if mode_change_or_system_start or min(lux_previous.intValue(), lux_current.intValue()) <= low_lux_trigger <= max(lux_previous.intValue(), lux_current.intValue()):
-                        action_function_names = get_key_value(item.name, "area_triggers_and_actions", "actions").keys()
-                        if not action_function_names or "light_action" in action_function_names:
-                            start_action(item, True if event is not None else trigger_group.state in [ON, OPEN], "light_action")
-                            if mode_change_or_system_start:
-                                mode_or_lux_change.log.info("Mode adjust: [{}]: {}: {}".format(items["Mode"], action_group.name, item.name))
+                    item_metadata = get_metadata(item.name, "area_triggers_and_actions")
+                    action_function_names = item_metadata.configuration.keys() if item_metadata else [AREA_TRIGGERS_AND_ACTIONS_CONFIGURATION.get("default_action_function")]
+                    for action_function_name in action_function_names:
+                        start_new_thread(start_action, (item, active, action_function_name))
+                #area_triggers.log.warn(u"Test: end loop: itemName: '{}', itemState: '{}', time: '{}'".format(event.itemName, event.itemState, DateTime.now().getMillis() - start_time))
+        else:
+            area_triggers.log.debug(u"No action group found for '{}'".format(event.itemName))
+        item_metadata = get_metadata(event.itemName, "area_triggers_and_actions")
+        trigger_function_names = item_metadata.configuration.keys() if item_metadata else []
+        for trigger_function_name in trigger_function_names:
+            start_new_thread(start_action, (itemRegistry.getItem(event.itemName), active, trigger_function_name))
+    #area_triggers.log.warn(u"Test: {}: '{}': time='{}'".format(event.itemName, event.itemState, DateTime.now().getMillis() - start_time))
+
+
+# The following rule will update the lights using the 'light_action'
+def lux_trigger_generator():
+    def generated_triggers(function):
+        lux_item_names = list(set([get_key_value(item.name, "area_triggers_and_actions", "light_action", "lux_item_name") for item in itemRegistry.getAll() if get_key_value(item.name, "area_triggers_and_actions", "light_action", "lux_item_name")]))
+        for lux_item_name in lux_item_names:
+            when("Item {} changed".format(lux_item_name))(function)
+        return function
+    return generated_triggers
+
+
+@rule("Mode or lux change", description="This rule will update the light levels when the Mode or lux changes. This is used with the default light_action function.")
+@lux_trigger_generator()
+@when("Item Mode changed")
+@when("System started")
+def mode_or_lux_change(event):
+    """
+    This rule iterates through all triggering groups and replays all actions
+    for groups that are currently active, using the current mode and lux level.
+    """
+    #start_time = DateTime.now().getMillis()
+    mode_change_or_system_start = (event.itemName == "Mode") if event is not None else True
+    # get a list of active trigger groups (or all of them, if system started)
+    for trigger_group in [group for group in itemRegistry.getItem("gArea_Trigger").members]:
+        trigger_type = "active" if trigger_group.state in [ON, OPEN] else "inactive"
+        action_groups = itemRegistry.getItems(trigger_group.name.replace("_Trigger", "_Action"))
+        if action_groups:
+            for action_group in action_groups:# there should be only 1 or None
+                for item in action_group.members:
+                    item_metadata = get_metadata(item.name, "area_triggers_and_actions")
+                    action_function_names = item_metadata.configuration.keys() if item_metadata else [AREA_TRIGGERS_AND_ACTIONS_CONFIGURATION.get("default_action_function")]
+                    if "light_action" in action_function_names:
+                        light_action_metadata = get_key_value(item.name, "area_triggers_and_actions", "light_action")
+                        lux_item_name = light_action_metadata.get("lux_item_name", AREA_TRIGGERS_AND_ACTIONS_CONFIGURATION.get("light_action", {}).get("lux_item_name"))
+                        if mode_change_or_system_start:
+                            start_new_thread(start_action, (item, trigger_group.state in [ON, OPEN], "light_action"))
+                            mode_or_lux_change.log.debug(u"Mode change or System start light adjustment: {}: {}: {}".format(items["Mode"], action_group.name, item.name))
+                        else:
+                            if lux_item_name == event.itemName and not isinstance(event.itemState, UnDefType):
+                                # the lux Item associated with the action Item has changed state
+                                lux_current = event.itemState.intValue()
+                                lux_previous = event.oldItemState.intValue()
+                            elif lux_item_name is not None and lux_item_name == AREA_TRIGGERS_AND_ACTIONS_CONFIGURATION.get("light_action", {}).get("lux_item_name") and not isinstance(items[lux_item_name], UnDefType):
+                                # this action Item is associated to the default lux Item
+                                lux_current = items[lux_item_name].intValue()
+                                lux_previous = PersistenceExtensions.previousState(itemRegistry.getItem(lux_item_name), True).state.intValue()
                             else:
-                                spanned = True
-                                mode_or_lux_change.log.info("Lux adjust: {}: {}: current=[{}], previous=[{}]".format(action_group.name, item.name, lux_current, lux_previous))
-        if not mode_change_or_system_start and not spanned:
-            mode_or_lux_change.log.debug("No lights were adjusted: current=[{}], previous=[{}]".format(lux_current, lux_previous))
-        #mode_or_lux_change.log.warn("Test: time=[{}]".format(DateTime.now().getMillis() - start_time))
+                                # this action Item is not associated to a lux Item and there is no default lux_item_name configured in AREA_TRIGGERS_AND_ACTIONS_CONFIGURATION
+                                break
+                            lux_trigger = light_action_metadata.get(trigger_type, {}).get("modes", {}).get(items["Mode"].toString(), {}).get("lux_trigger", AREA_TRIGGERS_AND_ACTIONS_CONFIGURATION["light_action"]["default_levels"][trigger_type]["lux_trigger"])
+                            if min(lux_previous, lux_current) < lux_trigger < max(lux_previous, lux_current):
+                                start_new_thread(start_action, (item, trigger_group.state in [ON, OPEN], "light_action"))
+                                mode_or_lux_change.log.debug(u"Lux change light adjustment: {}: {}: current: '{}', previous: '{}'".format(action_group.name, item.name, lux_current, lux_previous))
+    #mode_or_lux_change.log.warn(u"Test: time: '{}'".format(DateTime.now().getMillis() - start_time))

--- a/Community/Area Triggers and Actions/automation/jsr223/python/personal/area_triggers_and_actions/update_metadata.py.example
+++ b/Community/Area Triggers and Actions/automation/jsr223/python/personal/area_triggers_and_actions/update_metadata.py.example
@@ -1,15 +1,15 @@
 from core.metadata import set_metadata
 
 '''
-# which Items have an `area_triggers_and_actions` namespace?
+# Which Items have an `area_triggers_and_actions` namespace?
 from core.metadata import get_metadata
 from core.log import logging, LOG_PREFIX
 
-log = logging.getLogger("{}.area_triggers_and_actions.update_metadata".format(LOG_PREFIX))
+LOG = logging.getLogger("{}.area_triggers_and_actions.update_metadata".format(LOG_PREFIX))
 for item in ir.getAll():
     metadata = get_metadata(item.name, "area_triggers_and_actions")
     if metadata:
-        log.warn("{}: {}".format(item.name, metadata))
+        LOG.warn(u"{}: {}".format(item.name, metadata))
 '''
 
 '''
@@ -21,10 +21,10 @@ for item in ir.getAll():
 '''
 
 '''
-# This is the general metadata structure. Every option is listed but seldom are
-# they all used. Custom actions can make use of custom metadata structures, as
-# is done with the notification_action.
-
+# This is the general Item metadata structure that could be used for a specific
+# Item. Every option is listed but they are seldom all used. Custom actions can
+# make use of custom metadata structures, as is done in the notification_action
+# example.
 "Area_Triggers_and_Actions": {
     "modes": {
         "Morning": {"low_lux_trigger":5,  "hue":100, "saturation":100, "brightness":10},
@@ -36,13 +36,13 @@ for item in ir.getAll():
     },
     "actions": {
         "light_action": {
+            "lux_item_name": "DS_FamilyRoom_Lux",
             "ON": {
                 "delay": 0,
-                "recurring": False
             },
             "OFF": {
                 "delay": 60,
-                "recurring": True
+                "recurring": False
             }
         },
         "notification_action": {
@@ -60,7 +60,6 @@ for item in ir.getAll():
             },
             "OFF": {
                 "delay": 5,
-                "recurring": False
             }
         }
     }
@@ -70,19 +69,97 @@ for item in ir.getAll():
 '''
 # Examples
 
-set_metadata("gOutside_Door_Trigger", "area_triggers_and_actions", {"actions": {"notification_action": {"ON": {"delay": 3600, "types": {"audio": True, "mobile": True}, "Priority": 0, "recurring": True}}}}, overwrite=True)
+# set_metadata("gOutside_Door_Trigger", "area_triggers_and_actions", {
+#     "notification_action": {
+#         "limited": True,
+#         "active": {
+#             "delay": 3600,
+#             "types": {
+#                 "audio": True,
+#                 "mobile": True
+#             },
+#             "Priority": 0,
+#             "recurring": True
+#         }
+#     }
+# }, overwrite=True)
 
-set_metadata("US_GarageAttached_Dimmer", "area_triggers_and_actions", {"actions": {"light_action": {"OFF": {"delay": 180}}}}, overwrite=True)
+# set_metadata("US_GarageAttached_Dimmer", "area_triggers_and_actions", {
+#     "light_action": {
+#         "inactive": {
+#             "delay": 180
+#         }
+#     }
+# }, overwrite=True)
 
-set_metadata("DS_Office_Speaker_Player", "area_triggers_and_actions", {"actions": {"speaker_action": {"OFF": {"delay": 30}}}}, overwrite=True)
+# set_metadata("US_MasterBathroom_Speaker_Player", "area_triggers_and_actions", {
+#     "speaker_action": {
+#         "inactive": {
+#             "delay": 30
+#         }
+#     }
+# }, overwrite=True)
 
-set_metadata("DS_FamilyRoom_TV_LED_Color", "area_triggers_and_actions", {"modes": {"Morning": {"low_lux_trigger":5, "brightness":10, "hue":100, "saturation":100}, "Day": {"low_lux_trigger":55, "brightness":10, "hue":255, "saturation":100}, "Evening": {"low_lux_trigger":90, "brightness":10, "hue":255, "saturation":100}, "Night": {"low_lux_trigger":90, "brightness":10, "hue":240, "saturation":100}, "Late": {"low_lux_trigger":5, "brightness":10, "hue":0, "saturation":100}, "Party": {"low_lux_trigger":5, "brightness":10, "hue":0, "saturation":100}}}, overwrite=True)
+# set_metadata("gDS_Office_Bulb", "area_triggers_and_actions", {
+#     "light_action": {
+#         "lux_item_name": "ESP12E_01_Luminance",
+#         "active": {
+#             "modes": {
+#                 "Morning": {"lux_trigger": 0, "low_lux": {"brightness":1}},
+#                 "Day": {"lux_trigger": 0, "low_lux": {"brightness":98}},
+#                 "Evening": {"lux_trigger": 0, "low_lux": {"brightness":98}},
+#                 "Night": {"lux_trigger": 0, "low_lux": {"brightness":25}},
+#                 "Late": {"lux_trigger": 0, "low_lux": {"brightness":1}},
+#                 "Party": {"lux_trigger": 0, "low_lux": {"brightness":98}}
+#             }
+#         }
+#     }
+# }, overwrite=True)
 
-set_metadata("DS_Kitchen_Sink_Switch", "area_triggers_and_actions", {"modes": {"Morning": {"low_lux_trigger":5, "brightness":98}, "Day": {"low_lux_trigger":50, "brightness":98}, "Evening": {"low_lux_trigger":90, "brightness":98}, "Night": {"low_lux_trigger":90, "brightness":98}, "Late": {"low_lux_trigger":90, "brightness":0}}}, overwrite=True)
-set_metadata("DS_Kitchen_Spots_Dimmer", "area_triggers_and_actions", {"modes": {"Morning": {"low_lux_trigger":5, "brightness":98}, "Day": {"low_lux_trigger":50, "brightness":98}, "Evening": {"low_lux_trigger":90, "brightness":98}, "Night": {"low_lux_trigger":90, "brightness":98}, "Late": {"low_lux_trigger":90, "brightness":0}}}, overwrite=True)
-set_metadata("DS_Kitchen_Stove_Bulb", "area_triggers_and_actions", {"modes": {"Morning": {"low_lux_trigger":99999, "brightness":98}, "Day": {"low_lux_trigger":99999, "brightness":98}, "Evening": {"low_lux_trigger":99999, "brightness":98}, "Night": {"low_lux_trigger":99999, "brightness":55}, "Late": {"low_lux_trigger":99999, "brightness":10}}}, overwrite=True)
+# set_metadata("gOutsideLight", "area_triggers_and_actions", {
+#     "light_action": {
+#         "lux_item_name": "ESP12E_01_Luminance",
+#         "active": {
+#             "modes": {
+#                 "Morning": {"lux_trigger": 25, "low_lux": {"brightness":98}},
+#                 "Day": {"lux_trigger": 25, "low_lux": {"brightness":98}},
+#                 "Evening": {"lux_trigger": 25, "low_lux": {"brightness":98}},
+#                 "Night": {"lux_trigger": 25, "low_lux": {"brightness":98}},
+#                 "Late": {"lux_trigger": 25, "low_lux": {"brightness":98}},
+#                 "Party": {"lux_trigger": 25, "low_lux": {"brightness":98}}
+#             }
+#         }
+#     }
+# }, overwrite=True)
 
-set_metadata("Outlet5", "area_triggers_and_actions", {"modes": {"Morning": {"low_lux_trigger":5, "brightness":0}, "Day": {"low_lux_trigger":50, "brightness":0}, "Evening": {"low_lux_trigger":90, "brightness":0}, "Night": {"low_lux_trigger":90, "brightness":1}, "Late": {"low_lux_trigger":90, "brightness":1}, "Party": {"low_lux_trigger":90, "brightness":0}}}, overwrite=True)
+# set_metadata("US_DiningRoom_Dimmer", "area_triggers_and_actions", {
+#     "light_action": {
+#         "lux_item_name": "ESP12E_02_Luminance",
+#         "active": {
+#             "modes": {
+#                 "Morning": {"lux_trigger": 55, "low_lux": {"brightness":30}},
+#                 "Day": {"lux_trigger": 200, "low_lux": {"brightness":30}},
+#                 "Evening": {"lux_trigger": 200, "low_lux": {"brightness":30}},
+#                 "Night": {"lux_trigger": 200, "low_lux": {"brightness":30}},
+#                 "Late": {"lux_trigger": 55, "low_lux": {"brightness":1}},
+#                 "Party": {"lux_trigger": 0, "low_lux": {"brightness":30}}
+#             }
+#         }
+#     }
+# }, overwrite=True)
 
-set_metadata("gOutsideLight", "area_triggers_and_actions", {"modes": {"Morning": {"low_lux_trigger":5, "brightness":98}, "Day": {"low_lux_trigger":5, "brightness":98}, "Evening": {"low_lux_trigger":5, "brightness":98}, "Night": {"low_lux_trigger":5, "brightness":98}, "Late": {"low_lux_trigger":5, "brightness":98}, "Party": {"low_lux_trigger":90, "brightness":98}}}, overwrite=True)
-'''
+# set_metadata("DS_FamilyRoom_TV_LED_Color", "area_triggers_and_actions", {
+#     "light_action": {
+#         "lux_item_name": "ESP12E_01_Luminance",
+#         "active": {
+#             "modes": {
+#                 "Morning": {"lux_trigger": 55, "low_lux": {"brightness": 10, "hue": 100, "saturation":100}},
+#                 "Day": {"lux_trigger": 250, "low_lux": {"brightness": 0, "hue": 0, "saturation":0}},
+#                 "Evening": {"lux_trigger": 250, "low_lux": {"brightness": 10, "hue": 255, "saturation":100}},
+#                 "Night": {"lux_trigger": 250, "low_lux": {"brightness": 10, "hue": 240, "saturation":100}},
+#                 "Late": {"lux_trigger": 55, "low_lux": {"brightness": 10, "hue": 0, "saturation":100}},
+#                 "Party": {"lux_trigger": 0, "low_lux": {"brightness": 10, "hue": 0, "saturation":100}}
+#             }
+#         }
+#     }
+# }, overwrite=True)

--- a/Community/Area Triggers and Actions/automation/lib/python/community/area_triggers_and_actions/__init__.py
+++ b/Community/Area Triggers and Actions/automation/lib/python/community/area_triggers_and_actions/__init__.py
@@ -1,3 +1,4 @@
+# pylint: disable=wildcard-import
 """
 The ``area_triggers_and_actions`` package provides a mechanism for using group
 logic to trigger rules and then perform a particular action.
@@ -6,7 +7,7 @@ This package provides the following modules:
 
 * ``area_actions``
 """
-__all__ = ['start_action', 'stop_timer']
+__all__ = ['start_action']
 
 from threading import Timer
 
@@ -14,7 +15,7 @@ from core.jsr223.scope import ON, OFF, OPEN, CLOSED
 from core.metadata import get_key_value
 from core.log import logging, LOG_PREFIX, log_traceback
 
-from community.area_triggers_and_actions.area_actions import *
+from community.area_triggers_and_actions.area_actions import light_action, toggle_action
 
 try:
     import sys
@@ -26,20 +27,58 @@ except:
 
 #from org.joda.time import DateTime
 
-log = logging.getLogger("{}.community.area_triggers_and_actions".format(LOG_PREFIX))
+LOG = logging.getLogger(u"{}.community.area_triggers_and_actions".format(LOG_PREFIX))
 
-timer_dict = {}
+timers = {}
+iterations = {}
+
 
 @log_traceback
 def _timer_function(item, active, function_name, timer_type, timer_delay, recurring, function):
-    """This is the function called by the timers."""
-    #log.warn("_timer_function: item.name [{}], active [{}], function_name [{}], timer_type [{}], timer_delay [{}], function [{}]".format(item.name, active, function_name, timer_type, timer_delay, function))
+    """
+    This is the function called by the timers.
+
+    Args:
+        item Item: The Item to perform the action on
+        active bool: Area activity (True for active and False for inactive)
+        function_name str: Name of the action function
+        timer_type str: Type of the timer
+        timer_delay float: Time to delay the timer
+        recurring bool: Whether to repeatedly reschedule the timer after it expires
+        function function: The action function
+    """
+    #LOG.warn(u"_timer_function: item.name: '{}', active: '{}', function_name: '{}', timer_type: '{}', timer_delay: '{}', recurring: '{}', function: '{}'".format(item.name, str(active), function_name, timer_type, timer_delay, str(recurring), function))
     function(item, active)
-    log.debug("{}: [{}] second {} {} timer has completed".format(item.name, timer_delay, function_name, timer_type))
-    if recurring and item.state in [ON, OPEN] if active else item.state in [OFF, CLOSED]:
-        timer_dict.update({item.name: {function_name: {timer_type: Timer(timer_delay, _timer_function, [item, active, function_name, timer_type, timer_delay, recurring, function])}}})
-        timer_dict[item.name][function_name][timer_type].start()
-        log.debug("{}: [{}] second recurring {} {} timer has started".format(item.name, timer_delay, function_name, timer_type))
+    if recurring:
+        if iterations.get(item.name) is None:
+            timers.update({item.name: {function_name: {timer_type: Timer(timer_delay, _timer_function, [item, active, function_name, timer_type, timer_delay, recurring, function])}}})
+            timers[item.name][function_name][timer_type].start()
+            LOG.debug(u"{}: '{}' second recurring {} {} timer has started".format(item.name, timer_delay, function_name, timer_type))
+        elif iterations[item.name][timer_type] > 0:
+            iterations[item.name][timer_type] -= 1
+            timers.update({item.name: {function_name: {timer_type: Timer(timer_delay, _timer_function, [item, False if active else True, function_name, timer_type, timer_delay, recurring, function])}}})
+            timers[item.name][function_name][timer_type].start()
+            LOG.debug(u"{}: '{}' iterations of {} have started".format(item.name, iterations[item.name][timer_type] + 1, function_name))
+        else:
+            iterations[item.name][timer_type] = 0
+
+
+def _cancel_timer(item_name, function_name, timer_type):
+    """
+    This function cancels a timer.
+
+    Args:
+        item Item: The Item to perform the action on
+        function_name str: Name of the action function
+        timer_type str: Type of the timer
+    """
+    #LOG.warn(u"_cancel_timer:  item_name: '{}', function_name: '{}', timer_type: '{}'".format(item_name, function_name, timer_type))
+    if timers.get(item_name, {}).get(function_name, {}).get(timer_type) is not None and timers[item_name][function_name][timer_type].isAlive():# if timer exists, stop it
+        timers[item_name][function_name][timer_type].cancel()
+        if iterations.get(item_name) is not None:
+            iterations[item_name][timer_type] = 0
+        LOG.debug(u"{}: {} {} timer has been cancelled".format(item_name, function_name, timer_type))
+
 
 def start_action(item, active, function_name):
     """
@@ -48,31 +87,25 @@ def start_action(item, active, function_name):
 
     Args:
         item Item: The Item to perform the action on
-        active boolean: Area activity (True for active and False for inactive)
-        function_name string: Name of the action function
+        active bool: Area activity (True for active and False for inactive)
+        function_name str: Name of the action function
     """
     #start_time = DateTime.now().getMillis()
-    timer_type = "ON" if active else "OFF"
+    timer_type = "active" if active else "inactive"
     function = globals()[function_name]
-    function_metadata = get_key_value(item.name, "area_triggers_and_actions", "actions", function_name)
+    function_metadata = get_key_value(item.name, "area_triggers_and_actions", function_name)
     limited = function_metadata.get("limited")
     timer_metadata = function_metadata.get(timer_type, {})
-    if not limited or timer_metadata:
+    if timer_metadata or not limited:# this works since the states are binary
         timer_delay = timer_metadata.get("delay")
-        recurring = timer_metadata.get("recurring")
-        #log.warn("start_action: item.name [{}], active [{}], function_name [{}], timer_type [{}], timer_delay [{}], recurring [{}], function [{}]".format(item.name, active, function_name, timer_type, timer_delay, recurring, function))
         if not timer_delay:
             function(item, active)
-        elif timer_dict.get(item.name, {}).get(function_name, {}).get(timer_type) is None or not timer_dict[item.name][function_name][timer_type].isAlive():# if timer does not exist, create it
-            timer_dict.update({item.name: {function_name: {timer_type: Timer(timer_delay, _timer_function, [item, active, function_name, timer_type, timer_delay, recurring, function])}}})
-            timer_dict[item.name][function_name][timer_type].start()
-            log.debug("{}: [{}] second {}{} {} timer has started".format(item.name, timer_delay, "recurring " if recurring else "", function_name, timer_type))
-    stop_timer(item.name, function_name, "OFF" if active else "ON")
-    #log.warn("Test: start_action: {}: [{}]: time=[{}]".format(item.name, timer_type, DateTime.now().getMillis() - start_time))
-
-def stop_timer(item_name, function_name, timer_type):
-    """This function stops the timer."""
-    #log.warn("stop_timer: function_name [{}], timer_type [{}], item_name [{}]".format(function_name, timer_type, item_name))
-    if timer_dict.get(item_name, {}).get(function_name, {}).get(timer_type) is not None and timer_dict[item_name][function_name][timer_type].isAlive():# if timer exists, stop it
-        timer_dict[item_name][function_name][timer_type].cancel()
-        log.debug("{}: {} {} timer has been cancelled".format(item_name, function_name, timer_type))
+        elif timers.get(item.name, {}).get(function_name, {}).get(timer_type) is None or not timers[item.name][function_name][timer_type].isAlive():# if timer does not exist, create it
+            recurring = timer_metadata.get("recurring")
+            item_iterations = timer_metadata.get("iterations")
+            if item_iterations is not None and item_iterations > 0:
+                iterations.update({item.name: {timer_type: item_iterations}})
+            timers.update({item.name: {function_name: {timer_type: Timer(timer_delay, _timer_function, [item, active, function_name, timer_type, timer_delay, recurring, function])}}})
+            timers[item.name][function_name][timer_type].start()
+            LOG.debug(u"{}: '{}' second {}{} {} timer has started{}".format(item.name, timer_delay, "recurring " if recurring else "", function_name, timer_type, ", repeating {} times".format(item_iterations) if item_iterations else ""))
+    _cancel_timer(item.name, function_name, "inactive" if active else "active")

--- a/Community/Area Triggers and Actions/automation/lib/python/configuration.py.example
+++ b/Community/Area Triggers and Actions/automation/lib/python/configuration.py.example
@@ -1,30 +1,45 @@
 """
 Set the default values used when performing an area action on any Item that
-does not have these values set in its metadata.
+does not have these values set in its metadata. The light_action uses the
+following:
 
-* low_lux_trigger: the lux level at which lights should turn ON/OFF,
-* brightness: the dimming level for setting DimmerItems (anything greater than
+* ``lux_trigger``: when the lux level is greater/less than the lux_trigger, the
+  lights should turn ON/OFF
+* ``high_lux``: the brightness/color settings to use when the lux is higher than the lux_trigger
+* ``low_lux``: the brightness/color settings to use when the lux is lower than the lux_trigger
+* ``brightness``: the dimming level for setting DimmerItems (anything greater than
   zero will turn on a SwitchItem)
-* hue and saturation: for ColorItems
-* lux_item_name: the name of the Item to use for current outside lux or solar
-  radiation levels
+* ``hue`` and ``saturation``: for ColorItems
+* ``lux_item_name``: the name of the Item to use for outside lux or solar radiation
+  levels (if the Item state is QuantityType, the unit will be stripped)
 
 An easy way to get solar radiation values is an Item linked to the
 ``astro:sun:local:radiation#diffuse`` Channel from the Astro binding. This
-Channel provides a smoother curve than the direct and total Channels. The
-defaults set for color provide a warm white. By setting a high value for
-low_lux_trigger, the lights will always turn on, which works well for areas
-without windows, like closets.
+Channel provides a smoother curve than the ``radiation#direct`` and
+``radiation#total`` Channels. The defaults set for color provide a warm white.
+By setting ``lux_trigger`` to 0, the lights will always turn ON, which
+works well for areas without windows, like closets.
 
-Number:Intensity   Sun_Radiation_Diffuse  "Solar Radiation (diffuse) [%.0f W/m\u00B2]"    <sun>    {channel="astro:sun:local:radiation#diffuse"}
+--code-block
+
+    Number:Intensity   Sun_Radiation_Diffuse  "Solar Radiation (diffuse) [%.0f W/m²]"    <sun>    {channel="astro:sun:local:radiation#diffuse"}
 """
-area_triggers_and_actions_dict = {
-    #"lux_item_name": "Sun_Radiation_Diffuse",
-    "default_levels": {
-        "low_lux_trigger": 99999,
-        "hue": 30,
-        "saturation": 100,
-        "brightness": 98
-    },
-    "default_action_function": "light_action"
+AREA_TRIGGERS_AND_ACTIONS_CONFIGURATION = {
+    "default_action_function": "light_action",
+    "light_action": {
+        # "lux_item_name": "Sun_Radiation_Diffuse",
+        # "lux_item_name": "gLuminance",
+        "default_levels": {
+            "active": {
+                "lux_trigger": 0,# a lux_trigger of 0 will cause the light to not be adjusted based on the lux, like for use in a closet with no windows
+                "high_lux": {"hue": 0, "saturation": 0, "brightness": 0},# when the area is active and the lux is greater than the lux_trigger, the lights will be set to this level
+                "low_lux": {"hue": 30, "saturation": 100, "brightness": 98}# when the area is active and the lux is less than the lux_trigger, the lights will be set to this level
+            },
+            "inactive": {
+                "lux_trigger": 0,# a lux_trigger of 0 will cause the light to not be adjusted based on the lux, like for use in a closet with no windows
+                "high_lux": {"hue": 0, "saturation": 0, "brightness": 0},# when the area is inactive and the lux is greater than the lux_trigger, the lights will be set to this level
+                "low_lux": {"hue": 0, "saturation": 0, "brightness": 0}# when the area is inactive and the lux is less than the lux_trigger, the lights will be set to this level
+            }
+        }
+    }
 }

--- a/Community/Area Triggers and Actions/automation/lib/python/personal/area_triggers_and_actions/area_actions.py.example
+++ b/Community/Area Triggers and Actions/automation/lib/python/personal/area_triggers_and_actions/area_actions.py.example
@@ -3,6 +3,8 @@ The functions in this module are examples and are meant to be customized.
 """
 __all__ = ['speaker_action', 'notification_action']
 
+from org.joda.time import DateTime
+
 from core.jsr223.scope import events, items, StringType, OFF, PLAY
 from core.metadata import get_key_value
 from core.log import logging, LOG_PREFIX
@@ -10,9 +12,8 @@ from core.date import seconds_between, human_readable_seconds
 from core.actions import PersistenceExtensions
 from personal.utils import notification
 
-from org.joda.time import DateTime
+LOG = logging.getLogger("{}.personal.area_triggers_and_actions.area_actions".format(LOG_PREFIX))
 
-log = logging.getLogger("{}.personal.area_triggers_and_actions.area_actions".format(LOG_PREFIX))
 
 def speaker_action(item, active):
     """
@@ -29,25 +30,28 @@ def speaker_action(item, active):
         autoplay_mode_item_name = item.name.replace("_Player", "_AutoPlay_Mode")
         if items[autoplay_mode_item_name] == StringType("Sound Effects"):
             if items["Sound_Effect"] != StringType("Normal"):
-                log.debug("speaker_action: {}: sound effects".format(item.name))
+                LOG.debug("speaker_action: {}: sound effects".format(item.name))
                 if item.state != PLAY:
-                    workingPrefixList = str(items["Working_Prefix_List"]).split(",")
-                    if len(workingPrefixList) > 0:
+                    workingPrefixList = items["Working_Prefix_List"].toString().split(",")
+                    #if len(workingPrefixList) > 0:
+                    if workingPrefixList:
                         alertPrefixURI = workingPrefixList.pop()
-                        if len(workingPrefixList) > 0:
+                        #if len(workingPrefixList) > 0:
+                        if workingPrefixList > 0:
                             events.sendCommand("Working_Prefix_List", ",".join(workingPrefixList))
                         else:
-                            events.sendCommand("Sound_Effect", str(items["Sound_Effect"]))
-                        log.debug("speaker_action: {}: sound effects: alertPrefixURI=[{}]".format(item.name, alertPrefixURI))
+                            events.sendCommand("Sound_Effect", items["Sound_Effect"].toString())
+                        LOG.debug("speaker_action: {}: sound effects: alertPrefixURI=[{}]".format(item.name, alertPrefixURI))
                         events.sendCommand(item.name.replace("_Player", "_PlayURI"), alertPrefixURI)
         elif items[autoplay_mode_item_name] == StringType("House Shuffle"):
             if active:
-                if (items["Presence"] == StringType("Home") and str(items["Mode"]) not in ["Night", "Late"]) or items["Mode"] == StringType("Party"):
+                if (items["Presence"] == StringType("Home") and items["Mode"].toString() not in ["Night", "Late"]) or items["Mode"] == StringType("Party"):
                     if item.state != PLAY:
                         events.sendCommand(item.name.replace("_Player", "_PlayURI"), "HouseShuffle")
             else:
                 events.sendCommand(item.name.replace("_Player", "_Stop"), "ON")
-    #log.warn("Test: speaker_action: {}: [{}]: time=[{}]".format(item.name, "ON" if active else "OFF", DateTime.now().getMillis() - start_time))
+    #LOG.warn("Test: speaker_action: {}: [{}]: time=[{}]".format(item.name, "ON" if active else "OFF", DateTime.now().getMillis() - start_time))
+
 
 def notification_action(item, active):
     """
@@ -60,19 +64,24 @@ def notification_action(item, active):
         boolean active: Area activity (True for active and False for inactive)
     """
     #start_time = DateTime.now().getMillis()
-    timer_type = "ON" if active else "OFF"
-    notification_metadata = get_key_value(item.name, "area_triggers_and_actions", "actions", "notification_action", timer_type)
-    message = notification_metadata.get("message")
-    if message is None:
-        time_interval = seconds_between(PersistenceExtensions.previousState(item).timestamp, DateTime.now())
-        if time_interval < 1:
-            message = "{} is {}".format(item.label, "active" if active else "inactive")
-        else:
-            message = "{} has been {} for {}".format(item.label, "active" if active else "inactive", human_readable_seconds(time_interval))
-    types = notification_metadata.get("types", {})
-    priority = types.get("priority", 0)
-    audio = types.get("audio", False)
-    kodi = types.get("kodi", False)
-    mobile = types.get("mobile", False)
-    notification("Area Action", message, priority=priority, audio=audio, kodi=kodi, mobile=mobile)
-    #log.warn("Test: notification_action: {}: [{}]: time=[{}]".format(item.name, "ON" if active else "OFF", DateTime.now().getMillis() - start_time))
+    timer_type = "active" if active else "inactive"
+    notification_metadata = get_key_value(item.name, "area_triggers_and_actions", "notification_action")
+    notification_settings = notification_metadata.get(timer_type)
+    if notification_settings or not notification_metadata.get("limited"):# stop notifications for timer_types that should not notify, if any
+        message = notification_metadata.get(timer_type, {}).get("message")
+        if message is None:
+            start_time = PersistenceExtensions.previousState(item).timestamp
+            stop_time = DateTime.now().plusSeconds(1)
+            #LOG.warn("start_time: {}, stop_time: {}".format(start_time, stop_time))
+            time_interval = seconds_between(start_time, stop_time)
+            if time_interval < 1:# for immediate alerts
+                message = "{} is {}".format(item.label, timer_type)
+            else:
+                message = "{} has been {} for {}".format(item.label, timer_type, human_readable_seconds(time_interval))
+        types = notification_settings.get("types", {})
+        priority = types.get("priority", 0)
+        audio = types.get("audio", False)
+        kodi = types.get("kodi", False)
+        mobile = types.get("mobile", False)
+        notification(message, priority=priority, audio=audio, kodi=kodi, mobile=mobile)
+        #LOG.warn("Test: notification_action: {}: [{}]: time=[{}]".format(item.name, "ON" if active else "OFF", DateTime.now().getMillis() - start_time))


### PR DESCRIPTION
These changes allow you to set default high and low brightness/color settings. For example, when an area is active, but the lux is higher than the lux_trigger, you can set the light to be set to a brightness level. Previously, the only option was to turn it off. There is now an option for high/lox lux for when an area is active and inactive.

There were also changes to the names used in settings, so users upgrading should review all of the changes. Documentation updates to follow.

Signed-off-by: Scott Rushworth <github@5iver.com>