### PR TITLE
Add Items, Things, and Directories

### DIFF
--- a/Core/automation/lib/python/core/triggers.py
+++ b/Core/automation/lib/python/core/triggers.py
@@ -1,4 +1,3 @@
-# pylint: disable=wrong-import-position, dangerous-default-value
 """
 This module includes function decorators and Trigger subclasses to simplify
 Jython rule definitions.
@@ -21,47 +20,21 @@ for more details):
 * **ThingStatusChangeTrigger** - fires when the specified Thing's status changes **(requires S1636, 2.5M2 or newer)**
 * **ThingStatusUpdateTrigger** - fires when the specified Thing's status is updated **(requires S1636, 2.5M2 or newer)**
 * **ChannelEventTrigger** - fires when a Channel reports an Event
-* **DirectoryEventTrigger** - fires when a directory's contents changes
-* **ItemRegistryTrigger** - fires when the specified Item registry Event occurs
-* **ItemAddedTrigger** - fires when an Item is added (based on ``ItemRegistryTrigger``)
-* **ItemRemovedTrigger** - fires when an Item is removed (based on ``ItemRegistryTrigger``)
-* **ItemUpdatedTrigger** - fires when an Item is updated (based on ``ItemRegistryTrigger``)
 * **StartupTrigger** - fires when the rule is activated **(implemented in Jython and requires S1566, 2.5M2 or newer)**
+* **DirectoryEventTrigger** - fires when a directory reports an Event **(implemented in Jython and requires S1566, 2.5M2 or newer)**
 """
-import json
-from shlex import split
+from java.nio.file.StandardWatchEventKinds import ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY
 
 from core.jsr223.scope import scriptExtension
 scriptExtension.importPreset("RuleSupport")
-from core.jsr223.scope import itemRegistry, things, Trigger, TriggerBuilder, Configuration
-from core.osgi.events import OsgiEventTrigger
+from core.jsr223.scope import TriggerBuilder, Configuration, Trigger
 from core.utils import validate_uid
-from core.log import logging, LOG_PREFIX
-
-from java.nio.file.StandardWatchEventKinds import ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY
-
-from org.quartz.CronExpression import isValidExpression
-
-try:
-    from org.openhab.core.thing import ChannelUID, ThingUID, ThingStatus
-    from org.openab.core.thing.type import ChannelKind
-except:
-    from org.eclipse.smarthome.core.thing import ChannelUID, ThingUID, ThingStatus
-    from org.eclipse.smarthome.core.thing.type import ChannelKind
-
-try:
-    from org.eclipse.smarthome.core.types import TypeParser
-except:
-    from org.openhab.core.types import TypeParser
-
-LOG = logging.getLogger(u"{}.core.triggers".format(LOG_PREFIX))
 
 
 def when(target):
     """
-    This function decorator creates triggers attribute in the decorated
-    function that is used by the ``rule`` decorator when creating a rule.
-
+    This function decorator creates a ``triggers`` attribute in the decorated
+    function, which is used by the ``rule`` decorator when creating the rule.
     The ``when`` decorator simplifies the use of many of the triggers in this
     module and allows for them to be used with natural language similar to what
     is used in the rules DSL.
@@ -79,56 +52,84 @@ def when(target):
             @when("Descendent of gContact_Sensors changed from OPEN to CLOSED")
             @when("Item Test_Switch_2 received update ON")
             @when("Item Test_Switch_1 received command OFF")
+            @when("Item added")
+            @when("Item removed")
+            @when("Item updated")
+            @when("Thing added")
+            @when("Thing removed")
+            @when("Thing updated")
             @when("Thing kodi:kodi:familyroom changed")
             @when("Thing kodi:kodi:familyroom changed from ONLINE to OFFLINE")# requires S1636, 2.5M2 or newer
             @when("Thing kodi:kodi:familyroom received update ONLINE")# requires S1636, 2.5M2 or newer
             @when("Channel astro:sun:local:eclipse#event triggered START")# must use a Channel of kind Trigger
             @when("System started")# requires S1566, 2.5M2 or newer ('System shuts down' has not been implemented)
+            @when("Directory /opt/test [created, deleted, modified]")# requires S1566, 2.5M2 or newer
+            @when("Subdirectory 'C:\My Stuff' [created]")# requires S1566, 2.5M2 or newer
 
     Args:
         target (string): the `rules DSL-like formatted trigger expression <https://www.openhab.org/docs/configuration/rules-dsl.html#rule-triggers>`_
             to parse
     """
     try:
+        from os import path
+
+        from org.quartz.CronExpression import isValidExpression
+
+        from core.jsr223.scope import itemRegistry, things
+        from core.log import logging, LOG_PREFIX
+
+        try:
+            from org.openhab.core.thing import ChannelUID, ThingUID, ThingStatus
+            from org.openab.core.thing.type import ChannelKind
+        except:
+            from org.eclipse.smarthome.core.thing import ChannelUID, ThingUID, ThingStatus
+            from org.eclipse.smarthome.core.thing.type import ChannelKind
+
+        try:
+            from org.eclipse.smarthome.core.types import TypeParser
+        except:
+            from org.openhab.core.types import TypeParser
+
+        LOG = logging.getLogger(u"{}.core.triggers".format(LOG_PREFIX))
+
+
         def item_trigger(function):
             if not hasattr(function, 'triggers'):
                 function.triggers = []
-            item = itemRegistry.getItem(trigger_target)
-            group_members = []
-            if target_type == "Member of":
-                group_members = item.getMembers()
-            elif target_type == "Descendent of":
-                group_members = item.getAllMembers()
+            
+            if trigger_target in ["added", "removed", "updated"]:
+                event_names = {
+                    "added": "ItemAddedEvent",
+                    "removed": "ItemRemovedEvent",
+                    "updated": "ItemUpdatedEvent"
+                }
+                trigger_name = "Item-{}".format(event_names.get(trigger_target))
+                function.triggers.append(ItemEventTrigger(event_names.get(trigger_target), trigger_name=trigger_name).trigger)
             else:
-                group_members = [item]
-            for member in group_members:
-                trigger_name = "Item-{}-{}{}{}{}{}".format(
-                    member.name,
-                    trigger_type.replace(" ", "-"),
-                    "-from-{}".format(old_state) if old_state is not None else "",
-                    "-to-" if new_state is not None and trigger_type == "changed" else "",
-                    "-" if trigger_type == "received update" and new_state is not None else "",
-                    new_state if new_state is not None else "")
-                trigger_name = validate_uid(trigger_name)
-                if trigger_type == "received update":
-                    function.triggers.append(ItemStateUpdateTrigger(member.name, state=new_state, trigger_name=trigger_name).trigger)
-                elif trigger_type == "received command":
-                    function.triggers.append(ItemCommandTrigger(member.name, command=new_state, trigger_name=trigger_name).trigger)
+                item = itemRegistry.getItem(trigger_target)
+                group_members = []
+                if target_type == "Member of":
+                    group_members = item.getMembers()
+                elif target_type == "Descendent of":
+                    group_members = item.getAllMembers()
                 else:
-                    function.triggers.append(ItemStateChangeTrigger(member.name, previous_state=old_state, state=new_state, trigger_name=trigger_name).trigger)
-                LOG.debug(u"when: Created item_trigger: '{}'".format(trigger_name))
-            return function
-
-        def item_registry_trigger(function):
-            if not hasattr(function, 'triggers'):
-                function.triggers = []
-            event_names = {
-                'added': 'ItemAddedEvent',
-                'removed': 'ItemRemovedEvent',
-                'modified': 'ItemUpdatedEvent'
-            }
-            function.triggers.append(ItemRegistryTrigger(event_names.get(trigger_target)))
-            LOG.debug(u"when: Created item_registry_trigger: '{}'".format(event_names.get(trigger_target)))
+                    group_members = [item]
+                for member in group_members:
+                    trigger_name = "Item-{}-{}{}{}{}{}".format(
+                        member.name,
+                        trigger_type.replace(" ", "-"),
+                        "-from-{}".format(old_state) if old_state is not None else "",
+                        "-to-" if new_state is not None and trigger_type == "changed" else "",
+                        "-" if trigger_type == "received update" and new_state is not None else "",
+                        new_state if new_state is not None else "")
+                    trigger_name = validate_uid(trigger_name)
+                    if trigger_type == "received update":
+                        function.triggers.append(ItemStateUpdateTrigger(member.name, state=new_state, trigger_name=trigger_name).trigger)
+                    elif trigger_type == "received command":
+                        function.triggers.append(ItemCommandTrigger(member.name, command=new_state, trigger_name=trigger_name).trigger)
+                    else:
+                        function.triggers.append(ItemStateChangeTrigger(member.name, previous_state=old_state, state=new_state, trigger_name=trigger_name).trigger)
+                    LOG.debug(u"when: Created item_trigger: '{}'".format(trigger_name))
             return function
 
         def cron_trigger(function):
@@ -151,14 +152,21 @@ def when(target):
         def thing_trigger(function):
             if not hasattr(function, 'triggers'):
                 function.triggers = []
-            if new_state is not None or old_state is not None:
+            if trigger_target in ["added", "removed", "updated"]:
+                event_names = {
+                    "added": "ThingAddedEvent",
+                    "removed": "ThingRemovedEvent",
+                    "updated": "ThingUpdatedEvent"
+                }
+                function.triggers.append(ThingEventTrigger(event_names.get(trigger_target), trigger_name=trigger_name).trigger)
+            elif new_state is not None or old_state is not None:
                 if trigger_type == "changed":
                     function.triggers.append(ThingStatusChangeTrigger(trigger_target, previous_status=old_state, status=new_state, trigger_name=trigger_name).trigger)
                 else:
                     function.triggers.append(ThingStatusUpdateTrigger(trigger_target, status=new_state, trigger_name=trigger_name).trigger)
             else:
                 event_types = "ThingStatusInfoChangedEvent" if trigger_type == "changed" else "ThingStatusInfoEvent"
-                function.triggers.append(ThingEventTrigger(trigger_target, event_types, trigger_name=trigger_name).trigger)
+                function.triggers.append(ThingEventTrigger(event_types, trigger_target, trigger_name=trigger_name).trigger)
             LOG.debug(u"when: Created thing_trigger: '{}'".format(trigger_name))
             return function
 
@@ -166,6 +174,22 @@ def when(target):
             if not hasattr(function, 'triggers'):
                 function.triggers = []
             function.triggers.append(ChannelEventTrigger(trigger_target, event=new_state, trigger_name=trigger_name).trigger)
+            LOG.debug(u"when: Created channel_trigger: '{}'".format(trigger_name))
+            return function
+
+        def directory_trigger(function):
+            if not hasattr(function, 'triggers'):
+                function.triggers = []
+            event_kinds = []
+            if "created" in trigger_type:
+                event_kinds.append(ENTRY_CREATE)
+            if "deleted" in trigger_type:
+                event_kinds.append(ENTRY_DELETE)
+            if "modified" in trigger_type:
+                event_kinds.append(ENTRY_MODIFY)
+            if event_kinds == []:
+                event_kinds = [ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY]
+            function.triggers.append(DirectoryEventTrigger(trigger_target, event_kinds=event_kinds, watch_subdirectories=target_type == "Subdirectory", trigger_name=trigger_name).trigger)
             LOG.debug(u"when: Created channel_trigger: '{}'".format(trigger_name))
             return function
 
@@ -183,6 +207,8 @@ def when(target):
             trigger_type = target
             trigger_name = "Time-cron-{}".format(target)
         else:
+            from shlex import split
+
             input_list = split(target)
             if len(input_list) > 1:
                 # target_type trigger_target [trigger_type] [from] [old_state] [to] [new_state]
@@ -195,45 +221,66 @@ def when(target):
                             target_type = input_list.pop(0)
                     elif trigger_target is None:
                         if target_type == "System" and len(input_list) > 1:
-                            if " ".join(input_list[0:2]) == "shuts down":
-                                trigger_target = "shuts down"
+                            raise ValueError(u"when: \"{}\" could not be parsed. trigger_type '{}' is invalid for target_type 'System'. The only valid trigger_type is 'started'.".format(target, target_type))
+                            # if " ".join(input_list[0:2]) == "shuts down":
+                            #     trigger_target = "shuts down"
                         else:
                             trigger_target = input_list.pop(0)
                     elif trigger_type is None:
-                        if " ".join(input_list[0:2]) == "received update":
-                            if target_type in ["Item", "Thing", "Member of", "Descendent of"]:
-                                input_list = input_list[2:]
-                                trigger_type = "received update"
+                        if "received" in " ".join(input_list[0:2]):
+                            if " ".join(input_list[0:2]) == "received update":
+                                if target_type in ["Item", "Thing", "Member of", "Descendent of"]:
+                                    input_list = input_list[2:]
+                                    trigger_type = "received update"
+                                else:
+                                    raise ValueError(u"when: \"{}\" could not be parsed. 'received update' is invalid for target_type '{}'. The valid options are 'Item', 'Thing', 'Member of', or 'Descendent of'.".format(target, target_type))
+                            elif " ".join(input_list[0:2]) == "received command":
+                                if target_type in ["Item", "Member of", "Descendent of"]:
+                                    input_list = input_list[2:]
+                                    trigger_type = "received command"
+                                else:
+                                    raise ValueError(u"when: \"{}\" could not be parsed. 'received command' is invalid for target_type '{}'. The valid options are 'Item', 'Member of', or 'Descendent of'.".format(target, target_type))
                             else:
-                                raise ValueError(u"when: '{}' could not be parsed. 'received update' is invalid for target_type '{}'".format(target, target_type))
-                        elif " ".join(input_list[0:2]) == "received command":
-                            if target_type in ["Item", "Member of", "Descendent of"]:
-                                input_list = input_list[2:]
-                                trigger_type = "received command"
+                                raise ValueError(u"when: \"{}\" could not be parsed. '{}' is invalid for target_type '{}'. The valid options are 'received update' or 'received command'.".format(target, " ".join(input_list[0:2]), target_type))
+                        elif input_list[0][0] == "[":
+                            if input_list[0][-1] == "]":# if there are no spaces separating the event_kinds, it's ready to go
+                                trigger_type = input_list.pop(0).replace(" ", "").strip("[]'\"").split(",")
                             else:
-                                raise ValueError(u"when: '{}' could not be parsed. 'received command' is invalid for target_type '{}'".format(target, target_type))
+                                event_kinds = input_list.pop(0).replace(" ", "").strip("[]'\"")
+                                found_closing_bracket = False
+                                while input_list and not found_closing_bracket:
+                                    if input_list[0][-1] == "]":
+                                        found_closing_bracket = True
+                                    event_kinds = "{}{}".format(event_kinds, input_list.pop(0).replace(" ", "").strip("[]'\""))
+                                trigger_type = event_kinds.split(",")
+                            if target_type in ["Directory", "Subdirectory"]:
+                                for event_kind in trigger_type:
+                                    if event_kind not in ["created", "deleted", "modified"]:# ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY
+                                        raise ValueError(u"when: \"{}\" could not be parsed. trigger_type '{}' is invalid for target_type '{}'. The valid options are 'created', 'deleted', or 'modified'.".format(target, trigger_type, target_type))
+                            else:
+                                raise ValueError(u"when: \"{}\" could not be parsed. target_type '{}' is invalid for trigger_target '{}'. The valid options are 'Directory' or 'Subdirectory'.".format(target, target_type, trigger_target))
                         elif input_list[0] == "changed":
                             if target_type in ["Item", "Thing", "Member of", "Descendent of"]:
                                 input_list.pop(0)
                                 trigger_type = "changed"
                             else:
-                                raise ValueError(u"when: '{}' could not be parsed. 'changed' is invalid for target_type '{}'".format(target, target_type))
+                                raise ValueError(u"when: \"{}\" could not be parsed. 'changed' is invalid for target_type '{}'".format(target, target_type))
                         elif input_list[0] == "triggered":
                             if target_type == "Channel":
                                 trigger_type = input_list.pop(0)
                             else:
-                                raise ValueError(u"when: '{}' could not be parsed. 'triggered' is invalid for target_type '{}'".format(target, target_type))
+                                raise ValueError(u"when: \"{}\" could not be parsed. 'triggered' is invalid for target_type '{}'. The only valid option is 'Channel'.".format(target, target_type))
                         elif trigger_target == "cron":
                             if target_type == "Time":
                                 if isValidExpression(" ".join(input_list)):
                                     trigger_type = " ".join(input_list)
                                     del input_list[:]
                                 else:
-                                    raise ValueError(u"when: '{}' could not be parsed. '{}' is not a valid cron expression. See http://www.quartz-scheduler.org/documentation/quartz-2.1.x/tutorials/tutorial-lesson-06".format(target, " ".join(input_list)))
+                                    raise ValueError(u"when: \"{}\" could not be parsed. '{}' is not a valid cron expression. See http://www.quartz-scheduler.org/documentation/quartz-2.1.x/tutorials/tutorial-lesson-06.".format(target, " ".join(input_list)))
                             else:
-                                raise ValueError(u"when: '{}' could not be parsed. 'cron' is invalid for target_type '{}'".format(target, target_type))
+                                raise ValueError(u"when: \"{}\" could not be parsed. 'cron' is invalid for target_type '{}'".format(target, target_type))
                         else:
-                            raise ValueError(u"when: '{}' could not be parsed because the trigger_type {}".format(target, "is missing" if input_list[0] is None else "'{}' is invalid".format(input_list[0])))
+                            raise ValueError(u"when: \"{}\" could not be parsed because the trigger_type {}".format(target, "is missing" if input_list[0] is None else "'{}' is invalid".format(input_list[0])))
                     else:
                         if old_state is None and trigger_type == "changed" and input_list[0] == "from":
                             input_list.pop(0)
@@ -246,7 +293,7 @@ def when(target):
                         elif new_state is None and target_type == "Channel":
                             new_state = input_list.pop(0)
                         elif input_list:# there are no more possible combinations, but there is more data
-                            raise ValueError(u"when: '{}' could not be parsed. '{}' is invalid for '{} {} {}'".format(target, input_list, target_type, trigger_target, trigger_type))
+                            raise ValueError(u"when: \"{}\" could not be parsed. '{}' is invalid for '{} {} {}'".format(target, input_list, target_type, trigger_target, trigger_type))
 
             else:
                 # a simple Item target was used (just an Item name), so add a default target_type and trigger_type (Item XXXXX changed)
@@ -258,41 +305,44 @@ def when(target):
                     trigger_type = "changed"
 
         # validate the inputs, and if anything isn't populated correctly throw an exception
-        if target_type is None or target_type not in ["Item", "Member of", "Descendent of", "Thing", "Channel", "System", "Time"]:
-            raise ValueError(u"when: '{}' could not be parsed. target_type is missing or invalid. Valid target_type values are: Item, Member of, Descendent of, Thing, Channel, System, and Time.".format(target))
-        elif target_type != "System" and trigger_target not in ["added", "removed", "modified"] and trigger_type is None:
-            raise ValueError(u"when: '{}' could not be parsed because trigger_type cannot be None".format(target))
-        elif target_type in ["Item", "Member of", "Descendent of"] and trigger_target not in ["added", "removed", "modified"] and itemRegistry.getItems(trigger_target) == []:
-            raise ValueError(u"when: '{}' could not be parsed because Item '{}' is not in the ItemRegistry".format(target, trigger_target))
+        if target_type is None or target_type not in ["Item", "Member of", "Descendent of", "Thing", "Channel", "System", "Time", "Directory", "Subdirectory"]:
+            raise ValueError(u"when: \"{}\" could not be parsed. target_type is missing or invalid. Valid target_type values are: Item, Member of, Descendent of, Thing, Channel, System, Time, Directory, and Subdirectory.".format(target))
+        elif target_type != "System" and trigger_target not in ["added", "removed", "updated"] and trigger_type is None:
+            raise ValueError(u"when: \"{}\" could not be parsed because trigger_type cannot be None".format(target))
+        elif target_type in ["Item", "Member of", "Descendent of"] and trigger_target not in ["added", "removed", "updated"] and itemRegistry.getItems(trigger_target) == []:
+            raise ValueError(u"when: \"{}\" could not be parsed because Item '{}' is not in the ItemRegistry".format(target, trigger_target))
         elif target_type in ["Member of", "Descendent of"] and itemRegistry.getItem(trigger_target).type != "Group":
-            raise ValueError(u"when: '{}' could not be parsed because '{}' was specified, but '{}' is not a group".format(target, target_type, trigger_target))
-        elif target_type == "Item" and trigger_target not in ["added", "removed", "modified"] and old_state is not None and trigger_type == "changed" and TypeParser.parseState(itemRegistry.getItem(trigger_target).acceptedDataTypes, old_state) is None:
-            raise ValueError(u"when: '{}' could not be parsed because '{}' is not a valid state for '{}'".format(target, old_state, trigger_target))
-        elif target_type == "Item" and trigger_target not in ["added", "removed", "modified"] and new_state is not None and (trigger_type == "changed" or trigger_type == "received update") and TypeParser.parseState(itemRegistry.getItem(trigger_target).acceptedDataTypes, new_state) is None:
-            raise ValueError(u"when: '{}' could not be parsed because '{}' is not a valid state for '{}'".format(target, new_state, trigger_target))
-        elif target_type == "Item" and trigger_target not in ["added", "removed", "modified"] and new_state is not None and trigger_type == "received command" and TypeParser.parseCommand(itemRegistry.getItem(trigger_target).acceptedCommandTypes, new_state) is None:
-            raise ValueError(u"when: '{}' could not be parsed because '{}' is not a valid command for '{}'".format(target, new_state, trigger_target))
-        elif target_type == "Thing" and things.get(ThingUID(trigger_target)) is None:# returns null if Thing does not exist
-            raise ValueError(u"when: '{}' could not be parsed because Thing '{}' is not in the ThingRegistry".format(target, trigger_target))
+            raise ValueError(u"when: \"{}\" could not be parsed because '{}' was specified, but '{}' is not a group".format(target, target_type, trigger_target))
+        elif target_type == "Item" and trigger_target not in ["added", "removed", "updated"] and old_state is not None and trigger_type == "changed" and TypeParser.parseState(itemRegistry.getItem(trigger_target).acceptedDataTypes, old_state) is None:
+            raise ValueError(u"when: \"{}\" could not be parsed because '{}' is not a valid state for '{}'".format(target, old_state, trigger_target))
+        elif target_type == "Item" and trigger_target not in ["added", "removed", "updated"] and new_state is not None and (trigger_type == "changed" or trigger_type == "received update") and TypeParser.parseState(itemRegistry.getItem(trigger_target).acceptedDataTypes, new_state) is None:
+            raise ValueError(u"when: \"{}\" could not be parsed because '{}' is not a valid state for '{}'".format(target, new_state, trigger_target))
+        elif target_type == "Item" and trigger_target not in ["added", "removed", "updated"] and new_state is not None and trigger_type == "received command" and TypeParser.parseCommand(itemRegistry.getItem(trigger_target).acceptedCommandTypes, new_state) is None:
+            raise ValueError(u"when: \"{}\" could not be parsed because '{}' is not a valid command for '{}'".format(target, new_state, trigger_target))
+        elif target_type == "Thing" and trigger_target not in ["added", "removed", "updated"] and things.get(ThingUID(trigger_target)) is None:# returns null if Thing does not exist
+            raise ValueError(u"when: \"{}\" could not be parsed because Thing '{}' is not in the ThingRegistry".format(target, trigger_target))
         elif target_type == "Thing" and old_state is not None and not hasattr(ThingStatus, old_state):
             raise ValueError(u"when: '{}' is not a valid Thing status".format(old_state))
         elif target_type == "Thing" and new_state is not None and not hasattr(ThingStatus, new_state):
             raise ValueError(u"when: '{}' is not a valid Thing status".format(new_state))
+        elif target_type == "Thing" and trigger_target not in ["added", "removed", "updated"] and trigger_type is None:
+            raise ValueError(u"when: \"{}\" could not be parsed. trigger_target '{}' is invalid for target_type 'Thing'. The only valid trigger_type values are 'added', 'removed', and 'updated'.".format(target, trigger_target))
         elif target_type == "Channel" and things.getChannel(ChannelUID(trigger_target)) is None:# returns null if Channel does not exist
-            raise ValueError(u"when: '{}' could not be parsed because Channel '{}' does not exist".format(target, trigger_target))
+            raise ValueError(u"when: \"{}\" could not be parsed because Channel '{}' does not exist".format(target, trigger_target))
         elif target_type == "Channel" and things.getChannel(ChannelUID(trigger_target)).kind != ChannelKind.TRIGGER:
-            raise ValueError(u"when: '{}' could not be parsed because '{}' is not a trigger Channel".format(target, trigger_target))
+            raise ValueError(u"when: \"{}\" could not be parsed because '{}' is not a trigger Channel".format(target, trigger_target))
         elif target_type == "System" and trigger_target != "started":# and trigger_target != "shuts down":
-            raise ValueError(u"when: '{}' could not be parsed. trigger_target '{}' is invalid for target_type 'System'. The only valid trigger_type value is 'started'".format(target, target_type))# and 'shuts down'".format(target, target_type))
+            raise ValueError(u"when: \"{}\" could not be parsed. trigger_target '{}' is invalid for target_type 'System'. The only valid trigger_type value is 'started'.".format(target, target_type))# and 'shuts down'".format(target, target_type))
+        elif target_type in ["Directory", "Subdirectory"] and not path.isdir(trigger_target):
+            raise ValueError(u"when: \"{}\" could not be parsed. trigger_target '{}' does not exist or is not a directory.".format(target, target_type))
+        elif target_type in ["Directory", "Subdirectory"] and any(event_kind for event_kind in trigger_type if event_kind not in ["created", "deleted", "modified"]):
+            raise ValueError(u"when: \"{}\" could not be parsed. trigger_target '{}' is invalid for target_type '{}'.".format(target, trigger_target, target_type))
 
-        LOG.debug(u"when: target='{}', target_type='{}', trigger_target='{}', trigger_type='{}', old_state='{}', new_state='{}'".format(target, target_type, trigger_target, trigger_type, old_state, new_state))
+        LOG.debug(u"when: target: '{}', target_type: '{}', trigger_target: '{}', trigger_type: '{}', old_state: '{}', new_state: '{}'".format(target, target_type, trigger_target, trigger_type, old_state, new_state))
 
         trigger_name = validate_uid(trigger_name or target)
         if target_type in ["Item", "Member of", "Descendent of"]:
-            if trigger_target in ["added", "removed", "modified"]:
-                return item_registry_trigger
-            else:
-                return item_trigger
+            return item_trigger
         elif target_type == "Thing":
             return thing_trigger
         elif target_type == "Channel":
@@ -301,6 +351,8 @@ def when(target):
             return system_trigger
         elif target_type == "Time":
             return cron_trigger
+        elif target_type in ["Directory", "Subdirectory"]:
+            return directory_trigger
 
     except ValueError as ex:
         LOG.warn(ex)
@@ -311,7 +363,7 @@ def when(target):
             function.triggers.append(None)
             return function
 
-        # If there was a problem with a trigger configurationn, then add None
+        # If there was a problem with a trigger configuration, then add None
         # to the triggers attribute of the callback function, so that
         # core.rules.rule can identify that there was a problem and not start
         # the rule
@@ -320,6 +372,30 @@ def when(target):
     except:
         import traceback
         LOG.warn(traceback.format_exc())
+
+
+class CronTrigger(Trigger):
+    """
+    This class builds a CronTrigger Module to be used when creating a Rule.
+
+    See :ref:`Guides/Rules:Extensions` for examples of how to use these extensions.
+
+    Examples:
+        .. code-block::
+
+            MyRule.triggers = [CronTrigger("0 55 17 * * ?").trigger]
+
+    Args:
+        cron_expression (string): a valid `cron expression <http://www.quartz-scheduler.org/documentation/quartz-2.2.2/tutorials/tutorial-lesson-06.html>`_
+        trigger_name (string): (optional) name of this trigger
+
+    Attributes:
+        trigger (Trigger): Trigger object to be added to a Rule
+    """
+    def __init__(self, cron_expression, trigger_name=None):
+        trigger_name = validate_uid(trigger_name)
+        configuration = {'cronExpression': cron_expression}
+        self.trigger = TriggerBuilder.create().withId(trigger_name).withTypeUID("timer.GenericCronTrigger").withConfiguration(Configuration(configuration)).build()
 
 
 class ItemStateUpdateTrigger(Trigger):
@@ -342,7 +418,6 @@ class ItemStateUpdateTrigger(Trigger):
     Attributes:
         trigger (Trigger): Trigger object to be added to a Rule
     """
-
     def __init__(self, item_name, state=None, trigger_name=None):
         trigger_name = validate_uid(trigger_name)
         configuration = {"itemName": item_name}
@@ -360,7 +435,7 @@ class ItemStateChangeTrigger(Trigger):
     Examples:
         .. code-block::
 
-            MyRule.triggers = [ItemStateChangeTrigger("MyItem", "OFF", "ON", "MyItem-changed-from-OFF-to-ON").trigger]
+            MyRule.triggers = [ItemStateChangeTrigger("MyItem").trigger]
             MyRule.triggers.append(ItemStateChangeTrigger("MyOtherItem", "ON", "OFF","MyOtherItem-changed-from-ON-to-OFF").trigger)
 
     Args:
@@ -373,7 +448,6 @@ class ItemStateChangeTrigger(Trigger):
     Attributes:
         trigger (Trigger): Trigger object to be added to a Rule
     """
-
     def __init__(self, item_name, previous_state=None, state=None, trigger_name=None):
         trigger_name = validate_uid(trigger_name)
         configuration = {"itemName": item_name}
@@ -393,7 +467,7 @@ class ItemCommandTrigger(Trigger):
     Examples:
         .. code-block::
 
-            MyRule.triggers = [ItemCommandTrigger("MyItem", "ON", "MyItem-received-command-ON").trigger]
+            MyRule.triggers = [ItemCommandTrigger("MyItem").trigger]
             MyRule.triggers.append(ItemCommandTrigger("MyOtherItem", "OFF", "MyOtherItem-received-command-OFF").trigger)
 
     Args:
@@ -404,7 +478,6 @@ class ItemCommandTrigger(Trigger):
     Attributes:
         trigger (Trigger): Trigger object to be added to a Rule
     """
-
     def __init__(self, item_name, command=None, trigger_name=None):
         trigger_name = validate_uid(trigger_name)
         configuration = {"itemName": item_name}
@@ -433,7 +506,6 @@ class ThingStatusUpdateTrigger(Trigger):
     Attributes:
         trigger (Trigger): Trigger object to be added to a Rule.
     """
-
     def __init__(self, thing_uid, status=None, trigger_name=None):
         trigger_name = validate_uid(trigger_name)
         configuration = {"thingUID": thing_uid}
@@ -464,7 +536,6 @@ class ThingStatusChangeTrigger(Trigger):
     Attributes:
         trigger (Trigger): Trigger object to be added to a Rule
     """
-
     def __init__(self, thing_uid, previous_status=None, status=None, trigger_name=None):
         trigger_name = validate_uid(trigger_name)
         configuration = {"thingUID": thing_uid}
@@ -495,7 +566,6 @@ class ChannelEventTrigger(Trigger):
     Attributes:
         trigger (Trigger): Trigger object to be added to a Rule
     """
-
     def __init__(self, channel_uid, event=None, trigger_name=None):
         trigger_name = validate_uid(trigger_name)
         configuration = {"channelUID": channel_uid}
@@ -518,7 +588,7 @@ class GenericEventTrigger(Trigger):
             MyRule.triggers = [GenericEventTrigger("smarthome/items/Test_Switch_1/", "ItemStateEvent", "smarthome/items/*", "Test_Switch_1-received-update").trigger]
 
     Args:
-        eventSource (string): source to watch for trigger events
+        event_source (string): source to watch for trigger events
         event_types (string or list): types of events to watch
         event_topic (string): (optional) topic to watch
         trigger_name (string): (optional) name of this trigger
@@ -526,12 +596,11 @@ class GenericEventTrigger(Trigger):
     Attributes:
         trigger (Trigger): Trigger object to be added to a Rule
     """
-
     def __init__(self, event_source, event_types, event_topic="smarthome/*", trigger_name=None):
         trigger_name = validate_uid(trigger_name)
         self.trigger = TriggerBuilder.create().withId(trigger_name).withTypeUID("core.GenericEventTrigger").withConfiguration(Configuration({
             "eventTopic": event_topic,
-            "eventSource": "smarthome/{}/".format(event_source),
+            "eventSource": event_source,
             "eventTypes": event_types
         })).build()
 
@@ -539,10 +608,13 @@ class GenericEventTrigger(Trigger):
 class ItemEventTrigger(Trigger):
     """
     This class is the same as the ``GenericEventTrigger``, but simplifies it a bit for use with Items.
-    The available Item ``eventTypes`` are:
+    The available Item ``event_types`` are:
 
     .. code-block:: none
 
+        "ItemAddedEvent"
+        "ItemRemovedEvent"
+        "ItemUpdatedEvent"
         "ItemStateEvent" (Item state update)
         "ItemCommandEvent" (Item received Command)
         "ItemStateChangedEvent" (Item state changed)
@@ -565,12 +637,11 @@ class ItemEventTrigger(Trigger):
     Attributes:
         trigger (Trigger): Trigger object to be added to a Rule
     """
-
-    def __init__(self, event_source, event_types, event_topic="smarthome/items/*", trigger_name=None):
+    def __init__(self, event_types, item_name=None, trigger_name=None):
         trigger_name = validate_uid(trigger_name)
         self.trigger = TriggerBuilder.create().withId(trigger_name).withTypeUID("core.GenericEventTrigger").withConfiguration(Configuration({
-            "eventTopic": event_topic,
-            "eventSource": "smarthome/items/{}/".format(event_source),
+            "eventTopic": "smarthome/items/*",
+            "eventSource": "smarthome/items/{}".format("{}/".format(item_name) if item_name else ""),
             "eventTypes": event_types
         })).build()
 
@@ -578,66 +649,39 @@ class ItemEventTrigger(Trigger):
 class ThingEventTrigger(Trigger):
     """
     This class is the same as the ``GenericEventTrigger``, but simplifies it a bit for use with Things.
-    The available Thing ``eventTypes`` are:
+    The available Thing ``event_types`` are:
 
     .. code-block:: none
 
         "ThingAddedEvent"
         "ThingRemovedEvent"
-        "ThingStatusInfoChangedEvent"
-        "ThingStatusInfoEvent"
         "ThingUpdatedEvent"
+        "ThingStatusInfoEvent"
+        "ThingStatusInfoChangedEvent"
 
     See :ref:`Guides/Rules:Extensions` for examples of how to use these extensions.
 
     Examples:
         .. code-block::
 
-            MyRule.triggers = [ThingEventTrigger("kodi:kodi:familyroom", "ThingStatusInfoEvent").trigger]
+            MyRule.triggers = [ThingEventTrigger("ThingStatusInfoEvent", "kodi:kodi:familyroom").trigger]
 
     Args:
-        event_source (string): source to watch for trigger events
         event_types (string or list): types of events to watch
-        event_topic (string): (optional) topic to watch (no need to change
-            default)
+        thing_uid (string): (only used for ThingStatusInfoEvent and
+            ThingStatusInfoChangedEvent) the Thing to watch for events
         trigger_name (string): (optional) name of this trigger
 
     Attributes:
         trigger (Trigger): Trigger object to be added to a Rule
     """
-
-    def __init__(self, thing_uid, event_types, event_topic="smarthome/things/*", trigger_name=None):
+    def __init__(self, event_types, thing_uid=None, trigger_name=None):
         trigger_name = validate_uid(trigger_name)
         self.trigger = TriggerBuilder.create().withId(trigger_name).withTypeUID("core.GenericEventTrigger").withConfiguration(Configuration({
-            "eventTopic": event_topic,
-            "eventSource": "smarthome/things/{}/".format(thing_uid),
+            "eventTopic": "smarthome/things/*",
+            "eventSource": "smarthome/things/{}".format("{}/".format(thing_uid) if thing_uid else ""),
             "eventTypes": event_types
         })).build()
-
-
-class CronTrigger(Trigger):
-    """
-    This class builds a CronTrigger Module to be used when creating a Rule.
-
-    See :ref:`Guides/Rules:Extensions` for examples of how to use these extensions.
-
-    Examples:
-        .. code-block::
-
-            MyRule.triggers = [CronTrigger("0 55 17 * * ?").trigger]
-
-    Args:
-        cron_expression (string): a valid `cron expression <http://www.quartz-scheduler.org/documentation/quartz-2.2.2/tutorials/tutorial-lesson-06.html>`_
-        trigger_name (string): (optional) name of this trigger
-
-    Attributes:
-        trigger (Trigger): Trigger object to be added to a Rule
-    """
-
-    def __init__(self, cron_expression, trigger_name=None):
-        trigger_name = validate_uid(trigger_name)
-        configuration = {'cronExpression': cron_expression}
-        self.trigger = TriggerBuilder.create().withId(trigger_name).withTypeUID("timer.GenericCronTrigger").withConfiguration(Configuration(configuration)).build()
 
 
 class StartupTrigger(Trigger):
@@ -657,107 +701,9 @@ class StartupTrigger(Trigger):
     Attributes:
         trigger (Trigger): Trigger object to be added to a Rule
     """
-
     def __init__(self, trigger_name=None):
         trigger_name = validate_uid(trigger_name)
         self.trigger = TriggerBuilder.create().withId(trigger_name).withTypeUID("jsr223.StartupTrigger").withConfiguration(Configuration()).build()
-
-
-class ItemRegistryTrigger(OsgiEventTrigger):
-    """
-    This class builds an OsgiEventTrigger Module to be used when creating a
-    Rule. Requires the 100_OsgiEventTrigger.py component script. The available
-    Item registry ``event_names`` are:
-
-    .. code-block:: none
-
-        "ItemAddedEvent"
-        "ItemRemovedEvent"
-        "ItemUpdatedEvent"
-
-    See :ref:`Guides/Rules:Extensions` for examples of how to use these extensions.
-
-    Examples:
-        .. code-block::
-
-            MyRule.triggers = [ItemRegistryTrigger("ItemAddedEvent").trigger]
-
-    Args:
-        event_name (string): name of the event to watch
-
-    Attributes:
-        trigger (Trigger): Trigger object to be added to a Rule
-    """
-
-    def __init__(self, event_name):
-        OsgiEventTrigger.__init__(self)
-        self.event_name = event_name
-
-    def event_filter(self, event):
-        return event.get('type') == self.event_name
-
-    def event_transformer(self, event):
-        return json.loads(event['payload'])
-
-
-class ItemAddedTrigger(ItemRegistryTrigger):
-    """
-    This class is the same as the ``ItemRegistryTrigger``, but limited to when
-    an Item is added. This trigger will fire when any Item is added.
-
-    See :ref:`Guides/Rules:Extensions` for examples of how to use these extensions.
-
-    Examples:
-        .. code-block::
-
-            MyRule.triggers = [ItemAddedTrigger().trigger]
-
-    Attributes:
-        trigger (Trigger): Trigger object to be added to a Rule
-    """
-
-    def __init__(self):
-        ItemRegistryTrigger.__init__(self, "ItemAddedEvent")
-
-
-class ItemRemovedTrigger(ItemRegistryTrigger):
-    """
-    This class is the same as the ``ItemRegistryTrigger``, but limited to when
-    an Item is removed. This trigger will fire when any Item is removed.
-
-    See :ref:`Guides/Rules:Extensions` for examples of how to use these extensions.
-
-    Examples:
-        .. code-block::
-
-            MyRule.triggers = [ItemRemovedTrigger().trigger]
-
-    Attributes:
-        trigger (Trigger): Trigger object to be added to a Rule
-    """
-
-    def __init__(self):
-        ItemRegistryTrigger.__init__(self, "ItemRemovedEvent")
-
-
-class ItemUpdatedTrigger(ItemRegistryTrigger):
-    """
-    This class is the same as the ``ItemRegistryTrigger``, but limited to when
-    an Item is updated. This trigger will fire when any Item is updated.
-
-    See :ref:`Guides/Rules:Extensions` for examples of how to use these extensions.
-
-    Examples:
-        .. code-block::
-
-            MyRule.triggers = [ItemUpdatedTrigger().trigger]
-
-    Attributes:
-        trigger (Trigger): Trigger object to be added to a Rule
-    """
-
-    def __init__(self):
-        ItemRegistryTrigger.__init__(self, "ItemUpdatedEvent")
 
 
 class DirectoryEventTrigger(Trigger):
@@ -776,12 +722,11 @@ class DirectoryEventTrigger(Trigger):
     Attributes:
         trigger (Trigger): Trigger object to be added to a Rule
     """
-
-    def __init__(self, path, event_kinds=[ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY], watch_subdirectories=False):
-        trigger_name = validate_uid(type(self).__name__)
+    def __init__(self, path, event_kinds=[ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY], watch_subdirectories=False, trigger_name=None):
+        trigger_name = validate_uid(trigger_name)
         configuration = {
             'path': path,
             'event_kinds': str(event_kinds),
             'watch_subdirectories': watch_subdirectories,
         }
-        self.trigger = TriggerBuilder.create().withId(trigger_name).withTypeUID("jsr223.DirectoryTrigger").withConfiguration(Configuration(configuration)).build()
+        self.trigger = TriggerBuilder.create().withId(trigger_name).withTypeUID("jsr223.DirectoryEventTrigger").withConfiguration(Configuration(configuration)).build()


### PR DESCRIPTION
```
            @when("Item added")
            @when("Item removed")
            @when("Item updated")
            @when("Thing added")
            @when("Thing removed")
            @when("Thing updated")
            @when("Directory /opt/test [created, deleted, modified]")# requires S1566, 2.5M2 or newer
            @when("Subdirectory 'C:\My Stuff' [created]")# requires S1566, 2.5M2 or newer
```

One of the cool bits here is to be able to reload a rule using another rule when an Item or Thing is added/removed. Something like...

```
from core.rules import rule
from core.triggers import when


def zwave_thing_trigger_generator():
    def generated_triggers(function):
        for thing_uid in [thing.UID.toString() for thing in things.all if "zwave" in thing.UID.toString()]:
            when("Thing {} changed".format(thing_uid))(function)
        return function
    return generated_triggers


@rule("Z-Wave Thing added or removed")
@when("Thing added")
@when("Thing removed")
@when("System started")
def thing_added_or_removed(event):
    if event is not None:
        thing_added_or_removed.log.warn("thing: {}, topic: {}".format(event.thing.UID, event.topic.split("/")[-1]))
        scriptExtension.importPreset("RuleSupport")
        for my_rule in [my_rule for my_rule in rules.all if my_rule.name == "Alert: Z-Wave Thing"]:
            ruleRegistry.remove(my_rule.UID)

    @rule("Alert: Z-Wave Thing")
    @zwave_thing_trigger_generator()
    def zwave_thing_alert(event):
        zwave_thing_alert.log.warn("{} is '{}'".format(event.thingUID, event.statusInfo.status))
```
Something similar can be done for Items and a "Member of" trigger. Oh yeah... and DirectoryEventTrigger works again!

Signed-off-by: Scott Rushworth <github@5iver.com>