### PR TITLE
Update .pylintrc

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -40,7 +40,8 @@ disable=
     arguments-differ,
     redefined-builtin,
     redefined-outer-name,
-    invalid-encoded-data
+    invalid-encoded-data,
+    unsubscriptable-object
 
 [TYPECHECK]
 


### PR DESCRIPTION
Add 'unsubscriptable-object' to the list of disabled checks in order to avoid errors when filtering on tags for example.

Jython code example that causes an error: filter(lambda tag: tag.startswith('XYZ'), ir.getItem(event.itemName).getTags())
Error: "Value 'filter(lambda tag: tag.startswith('XYZ'), ir.getItem(event.itemName).getTags())' is unsubscriptablepylint(unsubscriptable-object)